### PR TITLE
Fix Alltest in laminarFlatPlateLTS for wallIntegratedHeatFlux test

### DIFF
--- a/run/hyStrath/hy2Foam/bluntedCone/Alltest
+++ b/run/hyStrath/hy2Foam/bluntedCone/Alltest
@@ -18,17 +18,17 @@ FILES_TO_TEST="stagnationLine_U.xy stagnationLine_Mach_Tt_Tv_p_rho.xy"
 for FILE in $FILES_TO_TEST
 do
   NLINES=`wc -l $RES_PATH/$FILE | awk '{print $1}'`
-  
+
   for LINE in `seq 1 $NLINES`
   do
     RES_LINEVALUE=`sed "${LINE}q;d" $RES_PATH/$FILE | awk '{print $2}'`
     SOL_LINEVALUE=`sed "${LINE}q;d" $SOL_PATH/$FILE | awk '{print $2}'`
-    
+
     RES_LINEVALUE=`awk '{ print +$1 }' <<< $RES_LINEVALUE`
     SOL_LINEVALUE=`awk '{ print +$1 }' <<< $SOL_LINEVALUE`
 
-    if [ `echo "$SOL_LINEVALUE*(1.0+$TOLERANCE) < $RES_LINEVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LINEVALUE*(1.0-$TOLERANCE) > $RES_LINEVALUE" | bc -l` -eq 1 ]; 
-    then echo "TEST FAILED: $FILE, line $LINE"; 
+    if [ `echo "$SOL_LINEVALUE*(1.0+$TOLERANCE) < $RES_LINEVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LINEVALUE*(1.0-$TOLERANCE) > $RES_LINEVALUE" | bc -l` -eq 1 ];
+    then echo "TEST FAILED: $FILE, line $LINE";
     fi
   done
 done
@@ -46,8 +46,8 @@ SOL_LASTVALUE=`tail -1 $SOL_PATH/$FILE_TO_TEST | awk '{print $3}'`
 RES_LASTVALUE=`awk '{ print +$1 }' <<< $RES_LASTVALUE`
 SOL_LASTVALUE=`awk '{ print +$1 }' <<< $SOL_LASTVALUE`
 
-if [ `echo "$SOL_LASTVALUE*(1.0+$TOLERANCE) < $RES_LASTVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LASTVALUE*(1.0-$TOLERANCE) > $RES_LASTVALUE" | bc -l` -eq 1 ]; 
-then echo "TEST FAILED: $FILE_TO_TEST"; 
+if [ `echo "$SOL_LASTVALUE*(1.0+$TOLERANCE) < $RES_LASTVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LASTVALUE*(1.0-$TOLERANCE) > $RES_LASTVALUE" | bc -l` -eq 1 ];
+then echo "TEST FAILED: $FILE_TO_TEST";
 fi
 
 
@@ -65,7 +65,6 @@ SOL_LASTVALUE=`tail -1 $SOL_PATH/$FILE_TO_TEST | awk '{print $2}'`
 RES_LASTVALUE=`awk '{ print +$1 }' <<< $RES_LASTVALUE`
 SOL_LASTVALUE=`awk '{ print +$1 }' <<< $SOL_LASTVALUE`
 
-if [ `echo "$SOL_LASTVALUE*(1.0+$TOLERANCE) < $RES_LASTVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LASTVALUE*(1.0-$TOLERANCE) > $RES_LASTVALUE" | bc -l` -eq 1 ]; 
-then echo "TEST FAILED: $FILE_TO_TEST"; 
+if [ `echo "$SOL_LASTVALUE*(1.0+$TOLERANCE) < $RES_LASTVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LASTVALUE*(1.0-$TOLERANCE) > $RES_LASTVALUE" | bc -l` -eq 1 ];
+then echo "TEST FAILED: $FILE_TO_TEST";
 fi
-

--- a/run/hyStrath/hy2Foam/bluntedCone/system/fvSchemes
+++ b/run/hyStrath/hy2Foam/bluntedCone/system/fvSchemes
@@ -26,7 +26,7 @@ gradSchemes
 {
     default           Gauss linear;
   //if convergence is difficult, add:
-  //grad(U)           cellLimited Gauss linear 1; 
+  //grad(U)           cellLimited Gauss linear 1;
 }
 
 divSchemes
@@ -34,16 +34,16 @@ divSchemes
     default           none;
     div(tauMC)        Gauss linear;
     div(phi,U)        Gauss limitedLinearV 1;
-    
+
     // Species diffusion
     div(diffusiveFluxes)   Gauss linear;
     div(phi,Yi_h)     Gauss limitedLinear 1;
-    
+
     // Turbulence modelling
     div(phi,k)        Gauss limitedLinear 1;
     div(phi,omega)    Gauss limitedLinear 1;
     div(phi,epsilon)  Gauss limitedLinear 1;
-    
+
     // Needed when there are electrons in the gas mix
     div(U)            Gauss linear;
 }

--- a/run/hyStrath/hy2Foam/bluntedCone/system/fvSolution
+++ b/run/hyStrath/hy2Foam/bluntedCone/system/fvSolution
@@ -38,8 +38,8 @@ solvers
         relTol          1e-3;
         minIter         1;
         maxIter         400;
-    }    
-   
+    }
+
     Yi
     {
         solver          PBiCG;
@@ -48,7 +48,7 @@ solvers
         relTol          0;
         maxIter         10;
     }
-    
+
     "(k|omega|epsilon)"
     {
     	  $U;

--- a/run/hyStrath/hy2Foam/bluntedCone/system/singleGraph
+++ b/run/hyStrath/hy2Foam/bluntedCone/system/singleGraph
@@ -43,7 +43,7 @@ sets
     }
 );
 
-fields 
+fields
 (
 	p
 	rho

--- a/run/hyStrath/hy2Foam/cylinderReactingMach20/system/fvSolution
+++ b/run/hyStrath/hy2Foam/cylinderReactingMach20/system/fvSolution
@@ -38,8 +38,8 @@ solvers
         relTol          1e-3;
         minIter         1;
         maxIter         400;
-    }    
-   
+    }
+
     Yi
     {
         solver          PBiCG;
@@ -48,7 +48,7 @@ solvers
         relTol          0;
         maxIter         10;
     }
-    
+
     "(k|omega|epsilon)"
     {
     	  $U;

--- a/run/hyStrath/hy2Foam/heatBath/system/fvSolution
+++ b/run/hyStrath/hy2Foam/heatBath/system/fvSolution
@@ -38,8 +38,8 @@ solvers
         relTol          1e-3;
         minIter         1;
         maxIter         400;
-    }    
-   
+    }
+
     Yi
     {
         solver          PBiCG;
@@ -48,7 +48,7 @@ solvers
         relTol          0;
         maxIter         10;
     }
-    
+
     "(k|omega|epsilon)"
     {
     	  $U;

--- a/run/hyStrath/hyFoam/axisymmetric-HB2/system/fvSolution
+++ b/run/hyStrath/hyFoam/axisymmetric-HB2/system/fvSolution
@@ -38,8 +38,8 @@ solvers
         relTol          1e-3;
         minIter         1;
         maxIter         400;
-    }    
-   
+    }
+
     Yi
     {
         solver          PBiCG;
@@ -48,7 +48,7 @@ solvers
         relTol          0;
         maxIter         10;
     }
-    
+
     "(k|omega|epsilon)"
     {
     	  $U;

--- a/run/hyStrath/hyFoam/laminarFlatPlateLTS/Allrun
+++ b/run/hyStrath/hyFoam/laminarFlatPlateLTS/Allrun
@@ -10,4 +10,3 @@ runApplication checkMesh
 hy2Foam > log.hyFoamLTS
 
 runApplication postProcess -func singleGraph -latestTime
-

--- a/run/hyStrath/hyFoam/laminarFlatPlateLTS/Alltest
+++ b/run/hyStrath/hyFoam/laminarFlatPlateLTS/Alltest
@@ -18,17 +18,17 @@ FILES_TO_TEST="line_U.xy line_Tt_p_rho.xy"
 for FILE in $FILES_TO_TEST
 do
   NLINES=`wc -l $RES_PATH/$FILE | awk '{print $1}'`
-  
+
   for LINE in `seq 1 $NLINES`
   do
     RES_LINEVALUE=`sed "${LINE}q;d" $RES_PATH/$FILE | awk '{print $2}'`
     SOL_LINEVALUE=`sed "${LINE}q;d" $SOL_PATH/$FILE | awk '{print $2}'`
-    
+
     RES_LINEVALUE=`awk '{ print +$1 }' <<< $RES_LINEVALUE`
     SOL_LINEVALUE=`awk '{ print +$1 }' <<< $SOL_LINEVALUE`
-    
-    if [ `echo "$SOL_LINEVALUE*(1.0+$TOLERANCE) < $RES_LINEVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LINEVALUE*(1.0-$TOLERANCE) > $RES_LINEVALUE" | bc -l` -eq 1 ]; 
-    then echo "TEST FAILED: $FILE, line $LINE"; 
+
+    if [ `echo "$SOL_LINEVALUE*(1.0+$TOLERANCE) < $RES_LINEVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LINEVALUE*(1.0-$TOLERANCE) > $RES_LINEVALUE" | bc -l` -eq 1 ];
+    then echo "TEST FAILED: $FILE, line $LINE";
     fi
   done
 done
@@ -46,8 +46,8 @@ SOL_LASTVALUE=`tail -1 $SOL_PATH/$FILE_TO_TEST | awk '{print $3}'`
 RES_LASTVALUE=`awk '{ print +$1 }' <<< $RES_LASTVALUE`
 SOL_LASTVALUE=`awk '{ print +$1 }' <<< $SOL_LASTVALUE`
 
-if [ `echo "$SOL_LASTVALUE*(1.0+$TOLERANCE) < $RES_LASTVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LASTVALUE*(1.0-$TOLERANCE) > $RES_LASTVALUE" | bc -l` -eq 1 ]; 
-then echo "TEST FAILED: $FILE_TO_TEST"; 
+if [ `echo "$SOL_LASTVALUE*(1.0+$TOLERANCE) < $RES_LASTVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LASTVALUE*(1.0-$TOLERANCE) > $RES_LASTVALUE" | bc -l` -eq 1 ];
+then echo "TEST FAILED: $FILE_TO_TEST";
 fi
 
 
@@ -65,7 +65,6 @@ SOL_LASTVALUE=`tail -1 $SOL_PATH/$FILE_TO_TEST | awk '{print $2}'`
 RES_LASTVALUE=`awk '{ print +$1 }' <<< $RES_LASTVALUE`
 SOL_LASTVALUE=`awk '{ print +$1 }' <<< $SOL_LASTVALUE`
 
-if [ `echo "$SOL_LASTVALUE*(1.0+$TOLERANCE) < $RES_LASTVALUE" | bc -l` -eq 1 ] || [ `echo "$SOL_LASTVALUE*(1.0-$TOLERANCE) > $RES_LASTVALUE" | bc -l` -eq 1 ]; 
-then echo "TEST FAILED: $FILE_TO_TEST"; 
+if [ `echo "a = ($SOL_LASTVALUE - $RES_LASTVALUE)/$SOL_LASTVALUE; sqrt(a*a) > $TOLERANCE" | bc -l` -eq 1 ];
+then echo "TEST FAILED: $FILE_TO_TEST";
 fi
-

--- a/run/hyStrath/hyFoam/laminarFlatPlateLTS/Alltest
+++ b/run/hyStrath/hyFoam/laminarFlatPlateLTS/Alltest
@@ -65,6 +65,6 @@ SOL_LASTVALUE=`tail -1 $SOL_PATH/$FILE_TO_TEST | awk '{print $2}'`
 RES_LASTVALUE=`awk '{ print +$1 }' <<< $RES_LASTVALUE`
 SOL_LASTVALUE=`awk '{ print +$1 }' <<< $SOL_LASTVALUE`
 
-if [ `echo "a = ($SOL_LASTVALUE - $RES_LASTVALUE)/$SOL_LASTVALUE; sqrt(a*a) > $TOLERANCE" | bc -l` -eq 1 ];
+if [ `echo "a = ($RES_LASTVALUE - $SOL_LASTVALUE)/$SOL_LASTVALUE; sqrt(a*a) > $TOLERANCE" | bc -l` -eq 1 ];
 then echo "TEST FAILED: $FILE_TO_TEST";
 fi

--- a/run/hyStrath/hyFoam/laminarFlatPlateLTS/system/fvSolution
+++ b/run/hyStrath/hyFoam/laminarFlatPlateLTS/system/fvSolution
@@ -38,8 +38,8 @@ solvers
         relTol          1e-3;
         minIter         1;
         maxIter         400;
-    }    
-   
+    }
+
     Yi
     {
         solver          PBiCG;
@@ -48,7 +48,7 @@ solvers
         relTol          0;
         maxIter         10;
     }
-    
+
     "(k|omega|epsilon)"
     {
     	  $U;

--- a/src/lagrangian/hybrid/molsToDel/derived/delFromHybridZone/delFromHybridZone.C
+++ b/src/lagrangian/hybrid/molsToDel/derived/delFromHybridZone/delFromHybridZone.C
@@ -40,8 +40,8 @@ defineTypeNameAndDebug(delFromHybridZone, 0);
 
 addToRunTimeSelectionTable
 (
-    molsToDeleteModel, 
-    delFromHybridZone, 
+    molsToDeleteModel,
+    delFromHybridZone,
     dictionary
 );
 
@@ -112,7 +112,7 @@ delFromHybridZone::delFromHybridZone
     typeIds_()
 {
     Info<< propsDict_.name() << endl;
-    
+
     const cellZoneMesh& cellZones = mesh_.cellZones();
     regionId_ = cellZones.findZoneID(regionName_);
 


### PR DESCRIPTION
Alltest fails for laminarFlatPlateLTS because the values in wallIntegratedHeatFlux are negative; this happens even if the solution file is copied to the postProcessing directory. I tried running the example in parallel (all processor cores) on an 8-core laptop twice, then on a single core once. I also ran the example in parallel and on a single core on a 12-core desktop. All tests failed even though they had an error within the tolerance.

I don't know why git changed a bunch of white space in various files, I only forked the repository and overwrote the Alltest file in laminarFlatPlateLTS with the modified version. All of the other examples either don't have an Alltest script or have positive values for wallIntegratedHeatFlux.