### PR TITLE
dsmcFoam+: fix bugs in several patch boundaries

### DIFF
--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcAbsorbingWallPatch/dsmcAbsorbingWallPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcAbsorbingWallPatch/dsmcAbsorbingWallPatch.C
@@ -42,7 +42,7 @@ void dsmcAbsorbingWallPatch::setProperties()
     if(molecules.size() == 0)
     {
         FatalErrorIn("dsmcAbsorbingWallPatch::setProperties()")
-            << "Cannot have zero typeIds being adsorbed." << nl << "in: "
+            << "Cannot have zero typeIds being absorbed." << nl << "in: "
             << mesh_.time().system()/"boundariesDict"
             << exit(FatalError);
     }
@@ -190,7 +190,7 @@ void dsmcAbsorbingWallPatch::testParticleForAbsorption
             mesh_.boundaryMesh()[wppIndex].whichFace(p.face());
                 
         //- absorption probability
-        const scalar absorptionProbability = absorptionProb(iD);
+        const scalar absorptionProbability = absorptionProbs_[iD];
             
         if
         (

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcAbsorbingWallPatch/dsmcAbsorbingWallPatch.H
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcAbsorbingWallPatch/dsmcAbsorbingWallPatch.H
@@ -76,7 +76,7 @@ protected:
 
     // Protected data  
     
-        //- typeIds to be adsorbed
+        //- typeIds to be absorbed
         labelList typeIds_;
         
         //- probability of absorption for each species in typeIds_

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcStickingWallPatch/dsmcStickingWallPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcStickingWallPatch/dsmcStickingWallPatch.C
@@ -96,15 +96,15 @@ void dsmcStickingWallPatch::setProperties()
         );
     }
     
-    residenceTime_.clear();
+    residenceTimes_.clear();
 
-    residenceTime_.setSize(typeIds_.size(), 0.0);
+    residenceTimes_.setSize(typeIds_.size(), 0.0);
     
-    forAll(residenceTime_, i)
+    forAll(residenceTimes_, i)
     {
         if (propsDict_.isDict("residenceTimes"))
         {
-            residenceTime_[i] =
+            residenceTimes_[i] =
             (
                 propsDict_.subDict("residenceTimes")
                     .lookupOrDefault<scalar>(moleculesReduced[i], VGREAT)
@@ -112,7 +112,7 @@ void dsmcStickingWallPatch::setProperties()
         }
         else
         {
-            residenceTime_[i] = VGREAT;
+            residenceTimes_[i] = VGREAT;
         }
     }
     
@@ -234,11 +234,8 @@ void dsmcStickingWallPatch::adsorbParticle
 
 void dsmcStickingWallPatch::testForDesorption(dsmcParcel& p)
 { 
-    //- Calculate the probability that this particle will be released
-    const label& iD = p.typeId(); //findIndex(typeIds_, p.typeId());
-    
-    /*Info << "p.typeId() " << p.typeId() << endl;
-    Info << "iD " << iD << endl;*/
+    const label typeId = p.typeId();
+    const label iD = findIndex(typeIds_, typeId);
     
     if(iD != -1)
     {
@@ -246,9 +243,10 @@ void dsmcStickingWallPatch::testForDesorption(dsmcParcel& p)
 
         Random& rndGen = cloud_.rndGen();
 
-        if(rndGen.sample01<scalar>() < deltaT/residenceTime_[iD])
+        //- Calculate the probability that this particle will be released
+        if(rndGen.sample01<scalar>() < deltaT/residenceTimes_[iD])
         {
-            const scalar mass = cloud_.constProps(iD).mass();
+            const scalar mass = cloud_.constProps(typeId).mass();
             
             vector& U = p.U();
             
@@ -398,7 +396,7 @@ dsmcStickingWallPatch::dsmcStickingWallPatch
     propsDict_(dict.subDict(typeName + "Properties")),
     typeIds_(),
     adsorptionProbs_(),
-    residenceTime_(),
+    residenceTimes_(),
     nStuckParcels_(mesh_.boundaryMesh()[patchId()].size(), 0.0),
     saturationLimit_(mesh_.boundaryMesh()[patchId()].size(), 0.0)
 {

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcStickingWallPatch/dsmcStickingWallPatch.H
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/dsmcStickingWallPatch/dsmcStickingWallPatch.H
@@ -82,7 +82,7 @@ protected:
         scalarList adsorptionProbs_;
         
         //- Residence time for a particle stuck to the wall
-        scalarList residenceTime_;
+        scalarList residenceTimes_;
         
         //- Number of stuck particles per face
         scalarList nStuckParcels_;
@@ -179,7 +179,7 @@ public:
         //- Return const access to all residence times
         const scalarList& residenceTimes() const
         {
-            return residenceTime_;
+            return residenceTimes_;
         }
         
         //- Return const access to the number of stuck parcels
@@ -249,7 +249,7 @@ public:
             
             if (iD != -1)
             {
-                return residenceTime_[iD];
+                return residenceTimes_[iD];
             }
             
             FatalErrorIn

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingDiffuseWallFieldPatch/dsmcAbsorbingDiffuseWallFieldPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingDiffuseWallFieldPatch/dsmcAbsorbingDiffuseWallFieldPatch.C
@@ -108,8 +108,7 @@ void dsmcAbsorbingDiffuseWallFieldPatch::controlParticle
     if(iD != -1) 
     {
         //- particle considered for absorption
-        const scalar absorptionProbability = 
-            dsmcAbsorbingDiffuseWallPatch::absorptionProb(iD);
+        const scalar absorptionProbability = absorptionProbs_[iD];
         
         const label wppIndex = patchId();
         

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingDiffuseWallPatch/dsmcAbsorbingDiffuseWallPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingDiffuseWallPatch/dsmcAbsorbingDiffuseWallPatch.C
@@ -105,7 +105,7 @@ void dsmcAbsorbingDiffuseWallPatch::controlParticle
     if(iD != -1) 
     {
         //- particle considered for absorption
-        const scalar absorptionProbability = absorptionProb(iD);
+        const scalar absorptionProbability = absorptionProbs_[iD];
         
         const label wppIndex = patchId();
         

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingStickingDiffuseWallFieldPatch/dsmcAbsorbingStickingDiffuseWallFieldPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingStickingDiffuseWallFieldPatch/dsmcAbsorbingStickingDiffuseWallFieldPatch.C
@@ -127,12 +127,10 @@ void dsmcAbsorbingStickingDiffuseWallFieldPatch::controlParticle
         if(iDab != -1 && iDst != -1) 
         {
             //- absorption probability
-            const scalar absorptionProbability = 
-                dsmcAbsorbingWallPatch::absorptionProb(iDab);
+            const scalar absorptionProbability = absorptionProbs_[iDab];
                 
             //- adsorption probability
-            const scalar adsorptionProbability = 
-                dsmcStickingWallPatch::adsorptionProb(iDst);
+            const scalar adsorptionProbability = adsorptionProbs_[iDst];
                 
             if
             (

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingStickingDiffuseWallPatch/dsmcAbsorbingStickingDiffuseWallPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcAbsorbingStickingDiffuseWallPatch/dsmcAbsorbingStickingDiffuseWallPatch.C
@@ -116,12 +116,10 @@ void dsmcAbsorbingStickingDiffuseWallPatch::controlParticle
         if(iDab != -1 && iDst != -1) 
         {
             //- absorption probability
-            const scalar absorptionProbability = 
-                dsmcAbsorbingWallPatch::absorptionProb(iDab);
+            const scalar absorptionProbability = absorptionProbs_[iDab];
                 
             //- adsorption probability
-            const scalar adsorptionProbability = 
-                dsmcStickingWallPatch::adsorptionProb(iDst);
+            const scalar adsorptionProbability = adsorptionProbs_[iDst];
                 
             if
             (

--- a/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcStickingDiffuseWallFieldPatch/dsmcStickingDiffuseWallFieldPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/patchBoundaries/mixed/dsmcStickingDiffuseWallFieldPatch/dsmcStickingDiffuseWallFieldPatch.C
@@ -105,7 +105,7 @@ void dsmcStickingDiffuseWallFieldPatch::controlParticle
         if(iD != -1)
         {
             //- particle considered for adsorption
-            const scalar adsorbtionProbability = adsorptionProb(iD);
+            const scalar adsorbtionProbability = adsorptionProbs_[iD];
             
             const label wppIndex = patchId();
             


### PR DESCRIPTION
This fixes several bugs in the dsmcFoam+ patch boundaries. These probably slipped by because they do not manifest until a mixture with multiple components is simulated. In the case of a single molecule type typeIds is always 1(0) therefore the index and the actual typeId will both be "0" and the wrong calls returned the correct values by accident.

This cleans up the code. Accessing the probabilities via the lists (e.g. adsorptionProbs_[index]) instead of the member functions (e.g. adsorptionProb(typeId)) was chosen deliberately to prevent another typeId -> findIndex conversion, thus reducing overhead.