### PR TITLE
[2/x] RWF fixes

### DIFF
--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
@@ -427,8 +427,6 @@ void dsmcLiouFangPressureInlet::controlParcelsAfterCollisions()
 
                 scalar sCosTheta = (inletVelocity_[f] & -sF/fA )/mostProbableSpeed;
 
-                //const scalar& RWF = cloud_.coordSystem().pRWF(patchId_, f); //cloud_.coordSystem().recalculatepRWF(faceI);
-
                 // From Bird eqn 4.22
                 accumulatedParcelsToInsert_[iD][f] +=
                 moleFractions_[iD]*

--- a/src/lagrangian/dsmc/clouds/dsmcCloud.H
+++ b/src/lagrangian/dsmc/clouds/dsmcCloud.H
@@ -331,14 +331,7 @@ public:
 
         //- Return the number of real particles represented by one parcel for
         //  a given cell
-        //  Locally in the code, the radialWeightingMethod (RWM) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        inline scalar nParticles
-        (
-            const label celli,
-            const bool mixedRWMethod = false
-        ) const;
+        inline scalar nParticles(const label celli) const;
 
         //- Return the number of real particles represented by one parcel for
         //  a given patch/face couple

--- a/src/lagrangian/dsmc/clouds/dsmcCloudI.H
+++ b/src/lagrangian/dsmc/clouds/dsmcCloudI.H
@@ -73,13 +73,9 @@ inline const Foam::volScalarField& Foam::dsmcCloud::nParticles() const
 }
 
 
-inline Foam::scalar Foam::dsmcCloud::nParticles
-(
-    const label celli,
-    const bool mixedRWMethod
-) const
+inline Foam::scalar Foam::dsmcCloud::nParticles(const label celli) const
 {
-    return coordSystem().nParticles(celli, mixedRWMethod);
+    return coordSystem().nParticles(celli);
 }
 
 

--- a/src/lagrangian/dsmc/collisionPartnerSelection/derived/noRepeatCollisions/noRepeatCollisions.C
+++ b/src/lagrangian/dsmc/collisionPartnerSelection/derived/noRepeatCollisions/noRepeatCollisions.C
@@ -269,7 +269,7 @@ void noRepeatCollisions::collide()
 
             scalar selectedPairs =
                 cloud_.collisionSelectionRemainder()[cellI]
-              + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI, true)*sigmaTcRMax*deltaT
+              + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI)*sigmaTcRMax*deltaT
                /mesh_.cellVolumes()[cellI];
 
             label nCandidates(selectedPairs);

--- a/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounter/noTimeCounter.C
+++ b/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounter/noTimeCounter.C
@@ -146,7 +146,7 @@ void noTimeCounter::collide()
 
             scalar selectedPairs =
                 cloud_.collisionSelectionRemainder()[cellI]
-                + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI, true)*sigmaTcRMax*deltaT
+                + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI)*sigmaTcRMax*deltaT
                 /cellVolume;
 
             const label nCandidates(selectedPairs);

--- a/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounterAdaptiveSubcelling/noTimeCounterAdaptiveSubcelling.C
+++ b/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounterAdaptiveSubcelling/noTimeCounterAdaptiveSubcelling.C
@@ -257,7 +257,7 @@ void noTimeCounterAdaptiveSubcelling::collide()
 
             scalar selectedPairs =
                 cloud_.collisionSelectionRemainder()[cellI]
-                + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI, true)*sigmaTcRMax*deltaT
+                + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI)*sigmaTcRMax*deltaT
                 /mesh.cellVolumes()[cellI];
 
             label nCandidates(selectedPairs);

--- a/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounterPorousMaterial/noTimeCounterPorousMaterial.C
+++ b/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounterPorousMaterial/noTimeCounterPorousMaterial.C
@@ -143,7 +143,7 @@ void noTimeCounterPorousMaterial::collide()
 
             scalar selectedPairs =
                 cloud_.collisionSelectionRemainder()[cellI]
-              + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI, true)*sigmaTcRMax*deltaT
+              + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI)*sigmaTcRMax*deltaT
                /mesh.cellVolumes()[cellI];
 
             label nCandidates(selectedPairs);

--- a/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounterSubCycled/noTimeCounterSubCycled.C
+++ b/src/lagrangian/dsmc/collisionPartnerSelection/derived/noTimeCounterSubCycled/noTimeCounterSubCycled.C
@@ -146,7 +146,7 @@ void noTimeCounterSubCycled::collide()
 
                 scalar selectedPairs =
                     cloud_.collisionSelectionRemainder()[cellI]
-                    + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI, true)*sigmaTcRMax*(deltaT/nSubCycles_)
+                    + 0.5*nC*(nC - 1)*cloud_.nParticles(cellI)*sigmaTcRMax*(deltaT/nSubCycles_)
                     /cellVolume;
 
                 label nCandidates(selectedPairs);

--- a/src/lagrangian/dsmc/collisionPartnerSelection/derived/simplifiedBernoulliTrials/simplifiedBernoulliTrials.C
+++ b/src/lagrangian/dsmc/collisionPartnerSelection/derived/simplifiedBernoulliTrials/simplifiedBernoulliTrials.C
@@ -107,7 +107,7 @@ void simplifiedBernoulliTrials::collide()
     {
         const scalar deltaT = cloud_.deltaTValue(cellI);
 
-        const scalar nParticle = cloud_.nParticles(cellI, true);
+        const scalar nParticle = cloud_.nParticles(cellI);
 
         const DynamicList<dsmcParcel*>& cellParcels(cellOccupancy[cellI]);
 

--- a/src/lagrangian/dsmc/collisionPartnerSelection/derived/simplifiedBernoulliTrialsTAS/simplifiedBernoulliTrialsTAS.C
+++ b/src/lagrangian/dsmc/collisionPartnerSelection/derived/simplifiedBernoulliTrialsTAS/simplifiedBernoulliTrialsTAS.C
@@ -251,7 +251,7 @@ void simplifiedBernoulliTrialsTAS::collide()
 
             }
 
-            scalar prob1 = (cloud_.nParticles(cellI, true)*deltaT)/(mesh.cellVolumes()[cellI]/nSubCells_[cellI]);
+            scalar prob1 = (cloud_.nParticles(cellI)*deltaT)/(mesh.cellVolumes()[cellI]/nSubCells_[cellI]);
             label k = -1;
             label candidateP = -1;
             label candidateQ = -1;

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
@@ -124,11 +124,7 @@ Foam::scalar Foam::dsmcCoordinateSystem::recalculatepRWF
 }
 
 
-Foam::scalar Foam::dsmcCoordinateSystem::recalculateRWF
-(
-    const label cellI,
-    const bool mixedRWMethod
-) const
+Foam::scalar Foam::dsmcCoordinateSystem::recalculateRWF(const label cellI) const
 {
     return 1.0;
 }

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
@@ -114,16 +114,6 @@ Foam::dsmcCoordinateSystem::~dsmcCoordinateSystem()
 
 // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
 
-Foam::scalar Foam::dsmcCoordinateSystem::recalculatepRWF
-(
-    const label patchI,
-    const label faceI
-) const
-{
-    return 1.0;
-}
-
-
 Foam::scalar Foam::dsmcCoordinateSystem::recalculateRWF(const label cellI) const
 {
     return 1.0;

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
@@ -160,14 +160,7 @@ public:
 
         //- Return const access to the number of real particles represented by
         //  a DSMC parcel for a given cell
-        //  Locally in the code, the radialWeightingMethod (RWM) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual inline scalar nParticles
-        (
-            const label celli,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual inline scalar nParticles(const label celli) const;
 
         //- Return const access to the number of real particles represented by
         //  a parcel for a given patch/face couple
@@ -190,14 +183,7 @@ public:
         );
 
         //- Return the local RWF for a given cell
-        //  Locally in the code, the radialWeightingMethod (RWM) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual inline scalar RWF
-        (
-            const label celli,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual inline scalar RWF(const label celli) const;
 
         //- Return the local RWF for a given face
         virtual inline scalar pRWF
@@ -230,14 +216,7 @@ public:
         ) const;
 
         //- Recalculate and return the radial weighting factor for a cell
-        //  Locally in the code, the radialWeightingMethod (rWMethod) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual scalar recalculateRWF
-        (
-            const label cellI,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual scalar recalculateRWF(const label cellI) const;
 
 
       // Write

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
@@ -170,18 +170,6 @@ public:
             const label facei
         ) const;
 
-        //- Return non-const access to the number of real particles represented
-        //  by a DSMC parcel for a given cell
-        virtual inline scalar nParticles(const label celli);
-
-        //- Return non-const access to the number of real particles represented
-        //  by a parcel for a given patch/face couple
-        virtual inline scalar nParticles
-        (
-            const label patchi,
-            const label facei
-        );
-
         //- Return the local RWF for a given cell
         virtual inline scalar RWF(const label celli) const;
 

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
@@ -207,14 +207,6 @@ public:
         //- Evolve function
         virtual void evolve() = 0;
 
-        //- Recalculate and return the radial weighting factor for a given
-        //  patch/face
-        virtual scalar recalculatepRWF
-        (
-            const label patchI,
-            const label faceI
-        ) const;
-
         //- Recalculate and return the radial weighting factor for a cell
         virtual scalar recalculateRWF(const label cellI) const;
 

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystemI.H
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystemI.H
@@ -87,22 +87,6 @@ inline scalar dsmcCoordinateSystem::nParticles
 }
 
 
-inline scalar dsmcCoordinateSystem::nParticles(const label celli)
-{
-    return timeStepModel_().nParticles(celli);
-}
-
-
-inline scalar dsmcCoordinateSystem::nParticles
-(
-    const label patchi,
-    const label facei
-)
-{
-    return timeStepModel_().nParticles(patchi, facei);
-}
-
-
 inline scalar dsmcCoordinateSystem::RWF(const label celli) const
 {
     return 1.0;

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystemI.H
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystemI.H
@@ -71,11 +71,7 @@ inline const volScalarField& dsmcCoordinateSystem::nParticles() const
 }
 
 
-inline scalar dsmcCoordinateSystem::nParticles
-(
-    const label celli,
-    const bool mixedRWMethod
-) const
+inline scalar dsmcCoordinateSystem::nParticles(const label celli) const
 {
     return timeStepModel_().nParticles(celli);
 }
@@ -107,11 +103,7 @@ inline scalar dsmcCoordinateSystem::nParticles
 }
 
 
-inline scalar dsmcCoordinateSystem::RWF
-(
-    const label celli,
-    const bool mixedRWMethod
-) const
+inline scalar dsmcCoordinateSystem::RWF(const label celli) const
 {
     return 1.0;
 }

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
@@ -210,20 +210,13 @@ void dsmcAxisymmetric::checkCoordinateSystemInputs(const bool init)
     rWMethod_ = cloud_.particleProperties().subDict("axisymmetricProperties")
         .lookupOrDefault<word>("radialWeightingMethod", "cell");
 
-    if
-    (
-        rWMethod_ != "cell" and rWMethod_ != "particle"
-            and rWMethod_ != "mixed"
-    )
+    if (rWMethod_ != "cell" and rWMethod_ != "particle")
     {
-        FatalErrorIn
-        (
-            "dsmcAxisymmetric::checkCoordinateSystemInputs(const bool init)"
-        )
-        << "The radial weighting method is badly defined. Choices "
-           "in constant/dsmcProperties are cell, particle, or "
-           "mixed. Please edit the entry: radialWeightingMethod"
-        << exit(FatalError);
+        FatalErrorInFunction
+            << "The radial weighting method is badly defined. Choices in "
+            << "constant/dsmcProperties are cell or particle. Please edit the "
+            << "entry: radialWeightingMethod."
+            << exit(FatalError);
     }
 
     const word& revolutionAxis =
@@ -376,15 +369,11 @@ scalar dsmcAxisymmetric::recalculatepRWF
 }
 
 
-scalar dsmcAxisymmetric::recalculateRWF
-(
-    const label cellI,
-    const bool mixedRWMethod
-) const
+scalar dsmcAxisymmetric::recalculateRWF(const label cellI) const
 {
     scalar RWF = 1.0;
 
-    if (rWMethod_ == "particle" or (mixedRWMethod and rWMethod_ == "mixed"))
+    if (rWMethod_ == "particle")
     {
         const DynamicList<dsmcParcel*>& cellParcels(cloud_.cellOccupancy()[cellI]);
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
@@ -210,12 +210,12 @@ void dsmcAxisymmetric::checkCoordinateSystemInputs(const bool init)
     rWMethod_ = cloud_.particleProperties().subDict("axisymmetricProperties")
         .lookupOrDefault<word>("radialWeightingMethod", "cell");
 
-    if (rWMethod_ != "cell" and rWMethod_ != "particle")
+    if (rWMethod_ != "cell" and rWMethod_ != "particleAverage")
     {
         FatalErrorInFunction
             << "The radial weighting method is badly defined. Choices in "
-            << "constant/dsmcProperties are cell or particle. Please edit the "
-            << "entry: radialWeightingMethod."
+            << "constant/dsmcProperties are \"cell\" or \"particleAverage\". "
+            << "Please edit the entry: radialWeightingMethod."
             << exit(FatalError);
     }
 
@@ -329,14 +329,15 @@ void dsmcAxisymmetric::checkCoordinateSystemInputs(const bool init)
 
     if (init)
     {
-        // "particle" cannot be used in dsmcInitialise, "cell" is thus employed
+        // "particleAverage" cannot be used in dsmcInitialise, "cell" is thus
+        // employed
         rWMethod_ = "cell";
 
         updateRWF();
     }
     else
     {
-        if (rWMethod_ != "particle")
+        if (rWMethod_ != "particleAverage")
         {
             updateRWF();
         }
@@ -346,7 +347,7 @@ void dsmcAxisymmetric::checkCoordinateSystemInputs(const bool init)
 
 void dsmcAxisymmetric::evolve()
 {
-    if (rWMethod_ == "particle")
+    if (rWMethod_ == "particleAverage")
     {
         updateRWF();
     }
@@ -373,7 +374,7 @@ scalar dsmcAxisymmetric::recalculateRWF(const label cellI) const
 {
     scalar RWF = 1.0;
 
-    if (rWMethod_ == "particle")
+    if (rWMethod_ == "particleAverage")
     {
         const DynamicList<dsmcParcel*>& cellParcels(cloud_.cellOccupancy()[cellI]);
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
@@ -144,7 +144,10 @@ void dsmcAxisymmetric::updateRWF()
 
         forAll(pRWF, facei)
         {
-            pRWF[facei] = recalculatepRWF(patchi, facei);
+            const label celli =
+                mesh_.boundaryMesh()[patchi].faceCells()[facei];
+
+            pRWF[facei] = RWF_[celli];
         }
     }
 }
@@ -354,19 +357,6 @@ void dsmcAxisymmetric::evolve()
 
     axisymmetricWeighting();
     cloud_.reBuildCellOccupancy();
-}
-
-
-scalar dsmcAxisymmetric::recalculatepRWF
-(
-    const label patchI,
-    const label faceI
-) const
-{
-    const point& fC = mesh_.boundaryMesh()[patchI].faceCentres()[faceI];
-    const scalar radius = mag(fC.component(polarAxis_));
-
-    return 1.0 + (maxRWF() - 1.0)*radius/radialExtent();
 }
 
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
@@ -78,7 +78,7 @@ class dsmcAxisymmetric
         scalar maxRWF_;
 
         //- Radial weighting method employed
-        //  Default: "cell", other options: "particle"
+        //  Default: "cell", other options: "particleAverage"
         word rWMethod_;
 
         //- Radial weighting factor field

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
@@ -78,7 +78,7 @@ class dsmcAxisymmetric
         scalar maxRWF_;
 
         //- Radial weighting method employed
-        //  Default: "cell", other options: "particle", "mixed"
+        //  Default: "cell", other options: "particle"
         word rWMethod_;
 
         //- Radial weighting factor field
@@ -135,14 +135,7 @@ public:
 
         //- Return const access to the number of real particles represented by
         //  a DSMC parcel for a given cell
-        //  Locally in the code, the radialWeightingMethod (RWM) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual inline scalar nParticles
-        (
-            const label celli,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual inline scalar nParticles(const label celli) const;
 
         //- Return const access to the number of real particles represented by
         //  a parcel for a given patch/face couple
@@ -165,14 +158,7 @@ public:
         );
 
         //- Return the local RWF for a given cell
-        //  Locally in the code, the radialWeightingMethod (RWM) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual inline scalar RWF
-        (
-            const label celli,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual inline scalar RWF(const label celli) const;
 
         //- Return the local RWF for a given face
         virtual inline scalar pRWF
@@ -205,14 +191,7 @@ public:
         ) const;
 
         //- Recalculate and return the radial weighting factor for a cell
-        //  Locally in the code, the radialWeightingMethod (rWMethod) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual scalar recalculateRWF
-        (
-            const label cellI,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual scalar recalculateRWF(const label cellI) const;
 
 
       // Write

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
@@ -145,18 +145,6 @@ public:
             const label facei
         ) const;
 
-        //- Return non-const access to the number of real particles represented
-        //  by a DSMC parcel for a given cell
-        virtual inline scalar nParticles(const label celli);
-
-        //- Return non-const access to the number of real particles represented
-        //  by a parcel for a given patch/face couple
-        virtual inline scalar nParticles
-        (
-            const label patchi,
-            const label facei
-        );
-
         //- Return the local RWF for a given cell
         virtual inline scalar RWF(const label celli) const;
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
@@ -182,14 +182,6 @@ public:
         //- Evolve function
         virtual void evolve();
 
-        //- Recalculate and return the radial weighting factor for a given
-        //  patch/face
-        virtual scalar recalculatepRWF
-        (
-            const label patchI,
-            const label faceI
-        ) const;
-
         //- Recalculate and return the radial weighting factor for a cell
         virtual scalar recalculateRWF(const label cellI) const;
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetricI.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetricI.H
@@ -69,22 +69,6 @@ inline scalar dsmcAxisymmetric::nParticles
 }
 
 
-inline scalar dsmcAxisymmetric::nParticles(const label celli)
-{
-    return timeStepModel_().nParticles(celli)*RWF(celli);
-}
-
-
-inline scalar dsmcAxisymmetric::nParticles
-(
-    const label patchi,
-    const label facei
-)
-{
-    return timeStepModel_().nParticles(patchi, facei)*pRWF(patchi, facei);
-}
-
-
 inline scalar dsmcAxisymmetric::RWF(const label celli) const
 {
     return RWF_[celli];

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetricI.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetricI.H
@@ -53,13 +53,9 @@ inline const volScalarField& dsmcAxisymmetric::nParticles() const
 }
 
 
-inline scalar dsmcAxisymmetric::nParticles
-(
-    const label celli,
-    const bool mixedRWMethod
-) const
+inline scalar dsmcAxisymmetric::nParticles(const label celli) const
 {
-    return timeStepModel_().nParticles(celli)*RWF(celli, mixedRWMethod);
+    return timeStepModel_().nParticles(celli)*RWF(celli);
 }
 
 
@@ -89,17 +85,8 @@ inline scalar dsmcAxisymmetric::nParticles
 }
 
 
-inline scalar dsmcAxisymmetric::RWF
-(
-    const label celli,
-    const bool mixedRWMethod
-) const
+inline scalar dsmcAxisymmetric::RWF(const label celli) const
 {
-    if (rWMethod_ == "mixed" and mixedRWMethod)
-    {
-        return recalculateRWF(celli, mixedRWMethod);
-    }
-
     return RWF_[celli];
 }
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
@@ -140,7 +140,10 @@ void dsmcSpherical::updateRWF()
 
         forAll(pRWF, facei)
         {
-            pRWF[facei] = recalculatepRWF(patchi, facei);
+            const label celli =
+                mesh_.boundaryMesh()[patchi].faceCells()[facei];
+
+            pRWF[facei] = RWF_[celli];
         }
     }
 }
@@ -261,25 +264,6 @@ void dsmcSpherical::evolve()
 
     sphericalWeighting();
     cloud_.reBuildCellOccupancy();
-}
-
-
-scalar dsmcSpherical::recalculatepRWF
-(
-    const label patchI,
-    const label faceI
-) const
-{
-    const point& fC = mesh_.boundaryMesh()[patchI].faceCentres()[faceI];
-    const scalar radius =
-        sqrt
-        (
-            sqr(fC.x() - origin_.x())
-          + sqr(fC.y() - origin_.y())
-          + sqr(fC.z() - origin_.z())
-        );
-
-    return 1.0 + (maxRWF() - 1.0)*sqr(radius/radialExtent());
 }
 
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
@@ -202,12 +202,12 @@ void dsmcSpherical::checkCoordinateSystemInputs(const bool init)
     rWMethod_ = cloud_.particleProperties().subDict("sphericalProperties")
         .lookupOrDefault<word>("radialWeightingMethod", "cell");
 
-    if (rWMethod_ != "cell" and rWMethod_ != "particle")
+    if (rWMethod_ != "cell" and rWMethod_ != "particleAverage")
     {
         FatalErrorInFunction
             << "The radial weighting method is badly defined. Choices in "
-            << "constant/dsmcProperties are cell or particle. Please edit the "
-            << "entry: radialWeightingMethod."
+            << "constant/dsmcProperties are \"cell\" or \"particleAverage\". "
+            << "Please edit the entry: radialWeightingMethod."
             << exit(FatalError);
     }
 
@@ -238,12 +238,13 @@ void dsmcSpherical::checkCoordinateSystemInputs(const bool init)
 
     if (init)
     {
-        // "particle" cannot be used in dsmcInitialise, "cell" is thus employed
+        // "particleAverage" cannot be used in dsmcInitialise, "cell" is thus
+        // employed
         rWMethod_ = "cell";
     }
     else
     {
-        if (rWMethod_ != "particle")
+        if (rWMethod_ != "particleAverage")
         {
             updateRWF();
         }
@@ -253,7 +254,7 @@ void dsmcSpherical::checkCoordinateSystemInputs(const bool init)
 
 void dsmcSpherical::evolve()
 {
-    if (rWMethod_ == "particle")
+    if (rWMethod_ == "particleAverage")
     {
         updateRWF();
     }
@@ -286,7 +287,7 @@ scalar dsmcSpherical::recalculateRWF(const label cellI) const
 {
     scalar RWF = 1.0;
 
-    if (rWMethod_ == "particle")
+    if (rWMethod_ == "particleAverage")
     {
         const DynamicList<dsmcParcel*>& cellParcels(cloud_.cellOccupancy()[cellI]);
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
@@ -202,20 +202,13 @@ void dsmcSpherical::checkCoordinateSystemInputs(const bool init)
     rWMethod_ = cloud_.particleProperties().subDict("sphericalProperties")
         .lookupOrDefault<word>("radialWeightingMethod", "cell");
 
-    if
-    (
-        rWMethod_ != "cell" and rWMethod_ != "particle"
-            and rWMethod_ != "mixed"
-    )
+    if (rWMethod_ != "cell" and rWMethod_ != "particle")
     {
-        FatalErrorIn
-        (
-            "dsmcSpherical::checkCoordinateSystemInputs(const bool init)"
-        )
-        << "The radial weighting method is badly defined. Choices "
-           "in constant/dsmcProperties are cell, particle, or "
-           "mixed. Please edit the entry: radialWeightingMethod"
-        << exit(FatalError);
+        FatalErrorInFunction
+            << "The radial weighting method is badly defined. Choices in "
+            << "constant/dsmcProperties are cell or particle. Please edit the "
+            << "entry: radialWeightingMethod."
+            << exit(FatalError);
     }
 
     maxRWF_ = readScalar
@@ -289,15 +282,11 @@ scalar dsmcSpherical::recalculatepRWF
 }
 
 
-scalar dsmcSpherical::recalculateRWF
-(
-    const label cellI,
-    const bool mixedRWMethod
-) const
+scalar dsmcSpherical::recalculateRWF(const label cellI) const
 {
     scalar RWF = 1.0;
 
-    if (rWMethod_ == "particle" or (mixedRWMethod and rWMethod_ == "mixed"))
+    if (rWMethod_ == "particle")
     {
         const DynamicList<dsmcParcel*>& cellParcels(cloud_.cellOccupancy()[cellI]);
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
@@ -70,7 +70,7 @@ class dsmcSpherical
         vector origin_;
 
         //- Radial weighting method employed
-        //  Default: "cell", other options: "particle"
+        //  Default: "cell", other options: "particleAverage"
         word rWMethod_;
 
         //- Radial weighting factor field

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
@@ -174,14 +174,6 @@ public:
         //- Evolve function
         virtual void evolve();
 
-        //- Recalculate and return the radial weighting factor for a given
-        //  patch/face
-        virtual scalar recalculatepRWF
-        (
-            const label patchI,
-            const label faceI
-        ) const;
-
         //- Recalculate and return the radial weighting factor for a cell
         virtual scalar recalculateRWF(const label cellI) const;
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
@@ -70,7 +70,7 @@ class dsmcSpherical
         vector origin_;
 
         //- Radial weighting method employed
-        //  Default: "cell", other options: "particle", "mixed"
+        //  Default: "cell", other options: "particle"
         word rWMethod_;
 
         //- Radial weighting factor field
@@ -127,14 +127,7 @@ public:
 
         //- Return const access to the number of real particles represented by
         //  a DSMC parcel for a given cell
-        //  Locally in the code, the radialWeightingMethod (RWM) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual inline scalar nParticles
-        (
-            const label celli,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual inline scalar nParticles(const label celli) const;
 
         //- Return const access to the number of real particles represented by
         //  a parcel for a given patch/face couple
@@ -157,14 +150,7 @@ public:
         );
 
         //- Return the local RWF for a given cell
-        //  Locally in the code, the radialWeightingMethod (RWM) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual inline scalar RWF
-        (
-            const label celli,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual inline scalar RWF(const label celli) const;
 
         //- Return the local RWF for a given face
         virtual inline scalar pRWF
@@ -197,14 +183,7 @@ public:
         ) const;
 
         //- Recalculate and return the radial weighting factor for a cell
-        //  Locally in the code, the radialWeightingMethod (rWMethod) can be
-        //  changed from "cell"- to "particle"-based if rWMethod is set to
-        //  mixed and the method call uses mixedRWM = true (e.g., nTC)
-        virtual scalar recalculateRWF
-        (
-            const label cellI,
-            const bool mixedRWMethod = false
-        ) const;
+        virtual scalar recalculateRWF(const label cellI) const;
 
 
       // Write

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
@@ -137,18 +137,6 @@ public:
             const label facei
         ) const;
 
-        //- Return non-const access to the number of real particles represented
-        //  by a DSMC parcel for a given cell
-        virtual inline scalar nParticles(const label celli);
-
-        //- Return non-const access to the number of real particles represented
-        //  by a parcel for a given patch/face couple
-        virtual inline scalar nParticles
-        (
-            const label patchi,
-            const label facei
-        );
-
         //- Return the local RWF for a given cell
         virtual inline scalar RWF(const label celli) const;
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSphericalI.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSphericalI.H
@@ -53,13 +53,9 @@ inline const volScalarField& dsmcSpherical::nParticles() const
 }
 
 
-inline scalar dsmcSpherical::nParticles
-(
-    const label celli,
-    const bool mixedRWMethod
-) const
+inline scalar dsmcSpherical::nParticles(const label celli) const
 {
-    return timeStepModel_().nParticles(celli)*RWF(celli, mixedRWMethod);
+    return timeStepModel_().nParticles(celli)*RWF(celli);
 }
 
 
@@ -89,17 +85,8 @@ inline scalar dsmcSpherical::nParticles
 }
 
 
-inline scalar dsmcSpherical::RWF
-(
-    const label celli,
-    const bool mixedRWMethod
-) const
+inline scalar dsmcSpherical::RWF(const label celli) const
 {
-    if (rWMethod_ == "mixed" and mixedRWMethod)
-    {
-        return recalculateRWF(celli, mixedRWMethod);
-    }
-
     return RWF_[celli];
 }
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSphericalI.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSphericalI.H
@@ -69,22 +69,6 @@ inline scalar dsmcSpherical::nParticles
 }
 
 
-inline scalar dsmcSpherical::nParticles(const label celli)
-{
-    return timeStepModel_().nParticles(celli)*RWF(celli);
-}
-
-
-inline scalar dsmcSpherical::nParticles
-(
-    const label patchi,
-    const label facei
-)
-{
-    return timeStepModel_().nParticles(patchi, facei)*pRWF(patchi, facei);
-}
-
-
 inline scalar dsmcSpherical::RWF(const label celli) const
 {
     return RWF_[celli];


### PR DESCRIPTION
Hi,
following are more fixes related to radial / spherical weighting.
While I tested them locally there might still be some bugs lurking around. However, in general the changes are rather simple so I would expect them to be okay.

Summary:
- remove the "mixed" radial weighting method as it was unsafe to use
- rename "particle" weighting method to "particleAverage" weighting method to prevent mix-up with truly particle based weighting where every parcel would have its own RWF
- set the boundary field of RWF to the cell values (i.e. RWF(patchi, facei) will now be the same as RWF(celli of the cell to which facei of patchi belongs). This was done because parcels always receive a cell-based RWF, therefore they should also be treated with that RWF when entering on or hitting a face. This should fix issue #37.
- I removed the non-const access functions for nParticles as I found no reason where this was used or even should be used. Please correct me if I am wrong and this has some kind of usecase.

Thanks :)
