### PR TITLE
dsmcFoam+: parcel: relocate stuck parcels after (processor) mesh change

### DIFF
--- a/src/lagrangian/dsmc/clouds/dsmcCloud.C
+++ b/src/lagrangian/dsmc/clouds/dsmcCloud.C
@@ -73,6 +73,22 @@ void Foam::dsmcCloud::buildCellOccupancy()
     }
 }
 
+void Foam::dsmcCloud::relocateStuckParcels()
+{
+    forAllIter(dsmcCloud, *this, iter)
+    {
+        if (iter().isStuck())
+        {
+            bool success = iter().relocateStuckParcel(mesh_);
+            if (!success)
+            {
+                FatalErrorInFunction
+                    << "Could not relocate stuck parcel!"
+                    << exit(FatalError);
+            }
+        }
+    }
+}
 
 void Foam::dsmcCloud::buildCellOccupancyFromScratch()
 {
@@ -80,6 +96,7 @@ void Foam::dsmcCloud::buildCellOccupancyFromScratch()
     cellOccupancy_.setSize(mesh_.nCells());
 
     buildCellOccupancy();
+    relocateStuckParcels();
 }
 
 void Foam::dsmcCloud::buildCollisionSelectionRemainderFromScratch()

--- a/src/lagrangian/dsmc/clouds/dsmcCloud.H
+++ b/src/lagrangian/dsmc/clouds/dsmcCloud.H
@@ -217,6 +217,9 @@ private:
         //- Record which particles are in which cell
         void buildCellOccupancy();
 
+        //- When mesh changed, relocate the patch/face of stuck parcels
+        void relocateStuckParcels();
+
         //- When mesh has changed, changed the size of cellOccupancy_
         void buildCellOccupancyFromScratch();
 

--- a/src/lagrangian/dsmc/parcels/dsmcParcel.H
+++ b/src/lagrangian/dsmc/parcels/dsmcParcel.H
@@ -1369,6 +1369,9 @@ public:
                 trackingData& td
             );
 
+
+        // Particle properties
+
             //- Transform the physical properties of the particle
             //  according to the given transformation tensor
             void transformProperties(const tensor& T);
@@ -1376,6 +1379,15 @@ public:
             //- Transform the physical properties of the particle
             //  according to the given separation vector
             void transformProperties(const vector& separation);
+
+            //- Relocate a stuck parcel
+            //  This is necessary after the mesh changed. In parallel the mesh
+            //  on each processor also changes after dynamic load balancing.
+            //  After such a change the saved patch and patch face of a stuck
+            //  parcel will not be valid anymore. This function finds the patch
+            //  and face in the new mesh. Returns true if a new patch/face was
+            //  found and allocated, false otherwise.
+            bool relocateStuckParcel(const polyMesh& mesh);
 
 
         // I-O


### PR DESCRIPTION
Hi,
this resolves issue #41 

Explanation:
To prevent solver crashes that will currently happen if stuck parcels are present and the mesh is changed we have to relocate the parcels on the new (processor) mesh. This patch will relocate all stuck parcels by finding the closest patch / patch face and reassigning them to the respective stuck parcels.