### PR TITLE
[dsmcFoam+] ENH: allow specifying a limit for the number of concurrent time directory backups to keep during load balancing

### DIFF
--- a/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.C
+++ b/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.C
@@ -71,8 +71,10 @@ dsmcDynamicLoadBalancing::dsmcDynamicLoadBalancing
     performBalance_(false),
     enableBalancing_(Switch(dsmcLoadBalanceDict_.lookup("enableBalancing"))),
     originalEndTime_(time_.time().endTime().value()),
-    maxImbalance_(readScalar(dsmcLoadBalanceDict_.lookup("maximumAllowableImbalance")))
-    //nProcs_(readLabel(dsmcLoadBalanceDict_.lookup("numberOfSubdomains")))
+    maxImbalance_(readScalar
+    (
+        dsmcLoadBalanceDict_.lookup("maximumAllowableImbalance")
+    ))
 {}
 
 // * * * * * * * * * * * * * * * * Destructor  * * * * * * * * * * * * * * * //
@@ -86,23 +88,7 @@ void dsmcDynamicLoadBalancing::update()
 {
     if(time_.time().outputTime())
     {
-        //- Checking for modifications in the IOdictionary
-        //  this allows for run-time tuning of any parameters.
-        // DLETED VINCENT: not useful
-
-        /*IOdictionary newDict
-        (
-            IOobject
-            (
-                "loadBalanceDict",
-                time_.system(),
-                mesh_,
-                IOobject::MUST_READ,
-                IOobject::NO_WRITE
-            )
-        );*/
-
-        updateProperties(/*newDict*/);
+        updateProperties();
 
         //- Load Balancing
         if (Pstream::parRun())
@@ -114,14 +100,16 @@ void dsmcDynamicLoadBalancing::update()
             scalar nGlobalParticles = cloud_.size();
             Foam::reduce(nGlobalParticles, sumOp<scalar>());
 
-            scalar idealNParticles = scalar(nGlobalParticles)/scalar(Pstream::nProcs());
+            scalar idealNParticles =
+                scalar(nGlobalParticles)/scalar(Pstream::nProcs());
 
             scalar nParticles = cloud_.size();
             scalar localImbalance = mag(nParticles - idealNParticles);
             Foam::reduce(localImbalance, maxOp<scalar>());
             scalar maxImbalance = localImbalance/idealNParticles;
 
-            Info << "    Maximum imbalance = " << 100*maxImbalance << "%" << endl;
+            Info<< "    Maximum imbalance = " << 100*maxImbalance << "%"
+                << endl;
 
             if( maxImbalance > allowableImbalance && enableBalancing_)
             {
@@ -147,12 +135,12 @@ void dsmcDynamicLoadBalancing::copyPolyMeshToLatestTimeFolder() const
         for (label i=0; i<Pstream::nProcs(); i++)
         {
             const word findStartTime =
-                "starting=`foamListTimes -processor -withZero -startTime`; ";
+                "starting=`foamListTimes -processor -withZero -startTime`;";
 
             if (findStartTime != "0")
             {
                 const word findLatestTime =
-                    "latest=`foamListTimes -processor -withZero -latestTime`; ";
+                    "latest=`foamListTimes -processor -withZero -latestTime`;";
                 const word findTimes = findStartTime + findLatestTime;
                 const word processorName = "processor" + name(i) + "/";
                 const word copyPolyMesh = findTimes + "cp -r "
@@ -163,18 +151,6 @@ void dsmcDynamicLoadBalancing::copyPolyMeshToLatestTimeFolder() const
             }
         }
     }
-    /*else
-    {
-        const word findLatestTime =
-                    "latest=`foamListTimes -processor -withZero -latestTime`; ";
-
-        const fileName polyMeshInTimeFolder = "processor0/" + findLatestTime + "/polyMesh";
-
-        if (isDir(polyMeshInTimeFolder))
-        {
-            const fileName constantInProcessor0 = "processor0/constant";
-        }
-    }*/
 }
 
 
@@ -188,51 +164,29 @@ void dsmcDynamicLoadBalancing::perform(const int noRefinement)
             {
                 copyPolyMeshToLatestTimeFolder();
             }
-
-            //string redistributeCommand("mpirun -np " + word(nProcs_) + " redistributeParDSMCLoadBalance -parallel");
-            //system("redistributeCommand");
-
-            /*const char reconstructParMeshCommand[] =
-                "reconstructParMesh -latestTime";
-
-            const word reconstructParCommand =
-                "reconstructPar -latestTime -parallel";
-
-            const word decomposeDSMCLoadBalanceParCommand =
-                "decomposeDSMCLoadBalancePar -force -latestTime -copyUniform -parallel";
-
-            const word decomposeDSMCCommand = word("var=`foamListTimes -noZero`; ")
-                + word("if [ -z ${var+x} ]; then echo 'error'; else ")
-                + decomposeDSMCLoadBalanceParCommand + word("; fi");*/
-
-            // Open MPI does not support recursive calls of mpirun
-            // MPI_Comm_spawn must be used instead
-            //int threading_level_required = MPI_THREAD_MULTIPLE;
-            //int threading_level_provided;
-            //MPI_Init_thread(0, 0, threading_level_required, &threading_level_provided);
-            /*MPI_Comm comm_to_workers;
-            char worker_program[100];
-            strcpy(worker_program, "hhh");*/
-
-            /*MPI_Comm_spawn(worker_program, MPI_ARGV_NULL, Pstream::nProcs(),
-                MPI_INFO_NULL, 0, MPI_COMM_SELF, &comm_to_workers, MPI_ERRCODES_IGNORE);*/
-
-            //system(reconstructParMeshCommand);
-            //system(reconstructParCommand);
-            //system("rm -r processor*");
-            //system(decomposeDSMCCommand);
-
             Foam::system("reconstructParMesh -latestTime");
             Foam::system("reconstructPar -latestTime");
             Foam::system("rm -r processor*");
 
-            Foam::system("var=`foamListTimes -noZero`; if [ -z ${var+x} ]; then echo 'error'; else decomposeDSMCLoadBalancePar -force -latestTime -copyUniform; fi");
+            const word decomposePar =
+                word("timeDirs=`foamListTimes -noZero`;")
+                // check if there are any time dirs, if not this indicates a
+                // fatal error
+                + word("if [ -z ${timeDirs+x} ];")
+                + word("then echo \"error\";")
+                // decompose the latest time dir
+                + word("else decomposeDSMCLoadBalancePar ")
+                + word("-force -latestTime -copyUniform;")
+                + word("fi");
+            Foam::system(decomposePar);
 
             // Backup folders must be stored in resultFolders and moved back
-            // as the simulation finishes
-            //system("foamListTimes -rm"); // no backup alternative but risky
+            // when the simulation finishes
             mkDir("resultFolders");
-            Foam::system("var2=`foamListTimes`; mv $var2 resultFolders");
+            Foam::system
+            (
+                "timeDirs=`foamListTimes`; mv $timeDirs resultFolders/"
+            );
 
             performBalance_ = false;
         }
@@ -241,13 +195,13 @@ void dsmcDynamicLoadBalancing::perform(const int noRefinement)
     }
 }
 
-void dsmcDynamicLoadBalancing::updateProperties
-(
-    /*const IOdictionary& newDict*/
-)
+void dsmcDynamicLoadBalancing::updateProperties()
 {
     enableBalancing_ = Switch(dsmcLoadBalanceDict_.lookup("enableBalancing"));
-    maxImbalance_ = readScalar(dsmcLoadBalanceDict_.lookup("maximumAllowableImbalance"));
+    maxImbalance_ = readScalar
+    (
+        dsmcLoadBalanceDict_.lookup("maximumAllowableImbalance")
+    );
 }
 
 // * * * * * * * * * * * * * * * Member Operators  * * * * * * * * * * * * * //

--- a/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
+++ b/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
@@ -70,6 +70,8 @@ class dsmcDynamicLoadBalancing
 
         bool enableBalancing_;
 
+        label limitTimeDirBackups_;
+
         scalar originalEndTime_;
 
         scalar maxImbalance_;

--- a/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
+++ b/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
@@ -66,8 +66,6 @@ class dsmcDynamicLoadBalancing
 
         IOdictionary dsmcLoadBalanceDict_;
 
-        //IOdictionary controlDict_;
-
         bool performBalance_;
 
         bool enableBalancing_;
@@ -76,10 +74,7 @@ class dsmcDynamicLoadBalancing
 
         scalar maxImbalance_;
 
-//         label nProcs_;
-
     // Private Member Functions
-
 
 
 public:
@@ -112,7 +107,7 @@ public:
         void copyPolyMeshToLatestTimeFolder() const;
 
 
-        void updateProperties(/*const IOdictionary&*/);
+        void updateProperties();
 
         // Access
 
@@ -146,7 +141,6 @@ public:
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
-//#include "dsmcDynamicLoadBalancingI.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 


### PR DESCRIPTION
Hi,
This is an enhancement to the dynamic load balancing. I wrote this because my time directories can become quite large (primarily due to the parcel velocity and position vectors). If several iterations of dynamic load balancing have to be carried out the resultFolders directory can become quite huge.

This patchset does:
- clean up the current code and add some clarifications
- add a new **optional** setting `limitTimeDirBackups` to the loadBalanceDict, where `limitTimeDirBackups` is the number of concurrent most recent time directory backups to keep in resultFolders.

The setting is implemented in such a way that it is completely optional and defaults to `-1`, which is interpreted as "backup limitless time directories" (i.e. the current behavior). Therefore all current cases - e.g. tutorials - run without any changes.

I thought this might also be useful to the community.