### PR TITLE
dsmcFoam+: RWF fixes 4

### DIFF
--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.C
@@ -114,9 +114,5 @@ Foam::dsmcCoordinateSystem::~dsmcCoordinateSystem()
 
 // * * * * * * * * * * * * * * * Member Functions  * * * * * * * * * * * * * //
 
-Foam::scalar Foam::dsmcCoordinateSystem::recalculateRWF(const label cellI) const
-{
-    return 1.0;
-}
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //

--- a/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
+++ b/src/lagrangian/dsmc/coordinateSystem/basic/dsmcCoordinateSystem.H
@@ -195,9 +195,6 @@ public:
         //- Evolve function
         virtual void evolve() = 0;
 
-        //- Recalculate and return the radial weighting factor for a cell
-        virtual scalar recalculateRWF(const label cellI) const;
-
 
       // Write
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.C
@@ -321,8 +321,8 @@ dsmcAxisymmetric::dsmcAxisymmetric
             "RWF",
             mesh_.time().timeName(),
             mesh_,
-            IOobject::NO_READ,
-            IOobject::NO_WRITE
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
         ),
         mesh_,
         dimensionedScalar("RWF", dimless, 1.0)
@@ -460,20 +460,17 @@ void dsmcAxisymmetric::checkCoordinateSystemInputs(const bool init)
 
     writeCoordinateSystemInfo();
 
+    // The RWFs have to be initialized only during the first run. This is done
+    // by dsmcInitialise+. After that the RWFs will be read from file during
+    // construction (this is for example the case in repeated running of
+    // dsmcFoam+ when using dynamic load balancing).
     if (init)
     {
-        // "particleAverage" cannot be used in dsmcInitialise, "cell" is thus
+        // "particleAverage" cannot be used in dsmcInitialise+, "cell" is thus
         // employed
         rWMethod_ = "cell";
 
         updateRWF();
-    }
-    else
-    {
-        if (rWMethod_ != "particleAverage")
-        {
-            updateRWF();
-        }
     }
 }
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/axisymmetric/dsmcAxisymmetric.H
@@ -93,6 +93,9 @@ class dsmcAxisymmetric
         //- Update the radial weighting factor field
         void updateRWF();
 
+        //- Recalculate and return the radial weighting factor for a cell
+        scalar recalculateRWF(const label cellI) const;
+
         //- Write axisymmetric info
         void writeAxisymmetricInfo() const;
 
@@ -169,9 +172,6 @@ public:
 
         //- Evolve function
         virtual void evolve();
-
-        //- Recalculate and return the radial weighting factor for a cell
-        virtual scalar recalculateRWF(const label cellI) const;
 
 
       // Write

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
@@ -320,8 +320,8 @@ dsmcSpherical::dsmcSpherical
             "RWF",
             mesh_.time().timeName(),
             mesh_,
-            IOobject::NO_READ,
-            IOobject::NO_WRITE
+            IOobject::READ_IF_PRESENT,
+            IOobject::AUTO_WRITE
         ),
         mesh_,
         dimensionedScalar("RWF", dimless, 1.0)
@@ -376,18 +376,15 @@ void dsmcSpherical::checkCoordinateSystemInputs(const bool init)
 
     writeCoordinateSystemInfo();
 
+    // The RWFs have to be initialized only during the first run. This is done
+    // by dsmcInitialise+. After that the RWFs will be read from file during
+    // construction (this is for example the case in repeated running of
+    // dsmcFoam+ when using dynamic load balancing).
     if (init)
     {
-        // "particleAverage" cannot be used in dsmcInitialise, "cell" is thus
+        // "particleAverage" cannot be used in dsmcInitialise+, "cell" is thus
         // employed
         rWMethod_ = "cell";
-    }
-    else
-    {
-        if (rWMethod_ != "particleAverage")
-        {
-            updateRWF();
-        }
     }
 }
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.C
@@ -385,6 +385,8 @@ void dsmcSpherical::checkCoordinateSystemInputs(const bool init)
         // "particleAverage" cannot be used in dsmcInitialise+, "cell" is thus
         // employed
         rWMethod_ = "cell";
+
+        updateRWF();
     }
 }
 

--- a/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
+++ b/src/lagrangian/dsmc/coordinateSystem/derived/spherical/dsmcSpherical.H
@@ -85,6 +85,9 @@ class dsmcSpherical
         //- Update the radial weighting factor field
         void updateRWF();
 
+        //- Recalculate and return the radial weighting factor for a cell
+        scalar recalculateRWF(const label cellI) const;
+
         //- Write spherical info
         void writeSphericalInfo() const;
 
@@ -161,9 +164,6 @@ public:
 
         //- Evolve function
         virtual void evolve();
-
-        //- Recalculate and return the radial weighting factor for a cell
-        virtual scalar recalculateRWF(const label cellI) const;
 
 
       // Write

--- a/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcInitialiseOnLine/dsmcInitialiseOnLine.C
+++ b/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcInitialiseOnLine/dsmcInitialiseOnLine.C
@@ -190,7 +190,7 @@ void dsmcInitialiseOnLine::setInitialConfiguration()
                 tetPt
             );
 
-            const scalar& RWF = cloud_.coordSystem().recalculateRWF(cellI);
+            const scalar& RWF = cloud_.coordSystem().RWF(cellI);
 
             cloud_.addNewParcel
             (

--- a/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcLaserHeatingFill/dsmcLaserHeatingFill.C
+++ b/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcLaserHeatingFill/dsmcLaserHeatingFill.C
@@ -189,7 +189,6 @@ void dsmcLaserHeatingFill::setInitialConfiguration()
                     // Calculate the number of particles required
                     scalar particlesRequired = numberDensity*tetVolume;
 
-                    //const scalar& RWF = cloud_.coordSystem().recalculateRWF(cellI);
                     particlesRequired /= cloud_.nParticles(cellI);
 
                     // Only integer numbers of particles can be inserted
@@ -242,7 +241,7 @@ void dsmcLaserHeatingFill::setInitialConfiguration()
 
                         label classification = 0;
 
-                        const scalar& RWF = cloud_.coordSystem().recalculateRWF(cellI);
+                        const scalar& RWF = cloud_.coordSystem().RWF(cellI);
 
                         cloud_.addNewParcel
                         (

--- a/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcMeshFill/dsmcMeshFill.C
+++ b/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcMeshFill/dsmcMeshFill.C
@@ -196,8 +196,7 @@ void dsmcMeshFill::setInitialConfiguration()
 
                     label classification = 0;
 
-                    const scalar& RWF =
-                        cloud_.coordSystem().recalculateRWF(cellI);
+                    const scalar& RWF = cloud_.coordSystem().RWF(cellI);
 
                     cloud_.addNewParcel
                     (

--- a/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcZoneFill/dsmcZoneFill.C
+++ b/src/lagrangian/dsmc/initialiseDsmcParcels/derived/dsmcZoneFill/dsmcZoneFill.C
@@ -170,7 +170,6 @@ void dsmcZoneFill::setInitialConfiguration()
                     // Calculate the number of particles required
                     scalar particlesRequired = numberDensity*tetVolume;
 
-                    //const scalar& RWF = cloud_.coordSystem().recalculateRWF(cellI);
                     particlesRequired /= cloud_.nParticles(cellI);
 
                     // Only integer numbers of particles can be inserted
@@ -223,7 +222,7 @@ void dsmcZoneFill::setInitialConfiguration()
 
                         label classification = 0;
 
-                        const scalar& RWF = cloud_.coordSystem().recalculateRWF(cellI);
+                        const scalar& RWF = cloud_.coordSystem().RWF(cellI);
 
                         cloud_.addNewParcel
                         (


### PR DESCRIPTION
Hi,
as announced in the last pull request these are some more RWF fixes.

summary:

**dsmcFoam+: parcel initialisation: remove incorrect RWF recalculation**
Remove the recalculation of RWFs during initialisation. Here the same problem could occur as in case of the injection boundaries. Calculation of the number of parcels to insert and the RWF of the inserted parcels should be consistent, therefore we should not recalculate the RWFs.

**dsmcFoam+: coord sys: remove public access to recalculating the RWF**
Remove the public access to RWF recalculation entirely. All places outside of the classes themselves have been deleted now anyways (except some deprecated stuff in the `WIP_` classes..), therefore make the recalculation function private to be more safe in the future. Recalculation is basically only safe during the evolve step (directly before weighting).

 **dsmcFoam+: coord sys: read/write RWFs from/to file to keep them consistent over solver restarts**
The RWF volScalarField is set to READ_IF_PRESENT and AUTO_WRITE. This is primarily relevant for particleAverage weighting during runs where dsmcFoam+ is restarted several times (e.g. dynamic load balancing). `updateRWF` is now only used during initialisation (dsmcInitialise+) and during the evolve step.

 **dsmcFoam+: spherical coord sys: add missing RWF update during initialisation**
I kept this as a separate commit because I never used the spherical weighting. In my understanding this should be analogous to axisymmetric weighting. Please correct me if this is wrong.

Please feel free to ask if anything is unclear. I should also stress that I am not using particleAverage weighting actively.