### PR TITLE
dsmcFoam+: dynamic load balancing: fix minor bugs

### DIFF
--- a/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.C
+++ b/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.C
@@ -207,11 +207,14 @@ void dsmcDynamicLoadBalancing::perform(const int noRefinement)
                 const word backupTimeDirsWithLimit =
                     // move the time dirs currently backed up to the case dir
                     // so the foamListTimes utility can be used
-                    word("mv resultFolders/* .;")
+                    // make sure directory is not empty to prevent mv from
+                    // printing a warning
+                    word("if [ \"$(ls -A resultFolders)\" ];")
+                    + word("then mv resultFolders/* .; fi;")
                     // total number of time directories
                     + word("timeDirs=`foamListTimes`;")
                     + word("nTimeDirs=$(echo $timeDirs | tr -cd ' ' | wc -c);")
-                    + word("$((nTimeDirs=nTimeDirs+1));")
+                    + word("nTimeDirs=$((nTimeDirs+1));")
                     // convert OpenFOAM label to shell variable for limit
                     + word("limitNTimeDirs=")
                     + name(limitTimeDirBackups_)

--- a/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
+++ b/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
@@ -28,7 +28,6 @@ Class
 Description
 
 SourceFiles
-    dsmcDynamicLoadBalancingI.H
     dsmcDynamicLoadBalancing.C
 
 \*---------------------------------------------------------------------------*/
@@ -70,11 +69,11 @@ class dsmcDynamicLoadBalancing
 
         bool enableBalancing_;
 
-        label limitTimeDirBackups_;
-
         scalar originalEndTime_;
 
         scalar maxImbalance_;
+
+        label limitTimeDirBackups_;
 
     // Private Member Functions
 


### PR DESCRIPTION
Hi,
this fixes some minor bugs that I introduced during the previous load balancing update:

- ordering issue between header file and constructor (compile time Wreorder warning)
- two shell issues where potential shell warnings where printed in the log files (should have been only cosmetic)