### PR TITLE
Flux surf

### DIFF
--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcChapmanEnskogFreeStreamInflowPatch/dsmcChapmanEnskogFreeStreamInflowPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcChapmanEnskogFreeStreamInflowPatch/dsmcChapmanEnskogFreeStreamInflowPatch.C
@@ -416,6 +416,12 @@ void dsmcChapmanEnskogFreeStreamInflowPatch::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 parcelsInserted[m] += 1.0;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowFieldPatch/dsmcFreeStreamInflowFieldPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowFieldPatch/dsmcFreeStreamInflowFieldPatch.C
@@ -382,6 +382,12 @@ void dsmcFreeStreamInflowFieldPatch::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 parcelsInserted[m] += 1.0;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowPatch/dsmcFreeStreamInflowPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowPatch/dsmcFreeStreamInflowPatch.C
@@ -364,6 +364,12 @@ void dsmcFreeStreamInflowPatch::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 parcelsInserted[m] += 1.0;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
@@ -332,6 +332,12 @@ void dsmcIsothermalPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMov
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
@@ -332,6 +332,12 @@ void dsmcLiouFangPressureInlet::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 nTotalParcelsAdded++;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
@@ -342,6 +342,12 @@ void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove
                         vibLevel
                     );
 
+                    // track this parcel as having crossed the boundary face
+                    // this is justified because the trackFraction of the parcel is
+                    // initialized as a random value in the interval [0, 1].
+                    // cf. dsmcParcel::move newParcel handling.
+                    cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                     nTotalParcelsAdded++;
                     parcelsInserted[iD]++;
                 }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
@@ -332,6 +332,12 @@ void dsmcLiouFangPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMove(
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
@@ -337,6 +337,12 @@ void dsmcMassFlowRateInlet::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
@@ -336,6 +336,12 @@ void dsmcNewPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 nTotalParcelsAdded++;
 
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
@@ -348,6 +348,12 @@ void dsmcWangPressureInlet::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
@@ -337,6 +337,12 @@ void dsmcYePressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
                     vibLevel
                 );
 
+                // track this parcel as having crossed the boundary face
+                // this is justified because the trackFraction of the parcel is
+                // initialized as a random value in the interval [0, 1].
+                // cf. dsmcParcel::move newParcel handling.
+                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
+
                 nTotalParcelsAdded++;
             }
         }

--- a/src/lagrangian/dsmc/faceTracker/dsmcFaceTracker.H
+++ b/src/lagrangian/dsmc/faceTracker/dsmcFaceTracker.H
@@ -93,9 +93,17 @@ public:
 
     // Member Functions
 
-        void updateFields
+        void trackParcelFaceTransition
         (
-            dsmcParcel& p
+            const dsmcParcel& p
+        );
+
+        void trackFaceTransition
+        (
+            const label& typeId,
+            const vector& U,
+            const scalar& RWF,
+            const label& crossedFaceI
         );
 
         void clean();

--- a/src/lagrangian/dsmc/parcels/dsmcParcel.C
+++ b/src/lagrangian/dsmc/parcels/dsmcParcel.C
@@ -104,7 +104,7 @@ bool Foam::dsmcParcel::move
             if (face() != -1)
             {
                 //- measure flux properties
-                td.cloud().tracker().updateFields(*this);
+                td.cloud().tracker().trackParcelFaceTransition(*this);
             }
 
             if (onBoundary() && td.keepParticle)

--- a/src/lagrangian/dsmc/parcels/dsmcParcel.C
+++ b/src/lagrangian/dsmc/parcels/dsmcParcel.C
@@ -51,6 +51,9 @@ bool Foam::dsmcParcel::move
 
         if (newParcel() != -1)
         {
+            // note: this justifies that freshly inserted parcels should be
+            // tracked as if they had passed the boundary face on which they
+            // have been inserted in the time step in which they are inserted.
             stepFraction() = td.cloud().rndGen().sample01<scalar>();
             newParcel() = -1;
         }


### PR DESCRIPTION
Hi,
This adds support for:

- tracking face transitions of parcels with all boundaries (i.e. also "normal" patches)
- tracking face transitions of freshly inserted parcels, meaning parcels generated on inflow boundaries, this is justified because we initialized the parcels with a random step fraction between 0..1, therefore these parcels should be treated as if they had crossed the boundary patches within the time step in which they are initialized

Note: I could not find a more elegant solution to track the parcels at the inflow boundaries than the one I currently implemented. Please let me know if there is a better solution. Returning a reference to the newly added parcel from the cloud class (i.e. from the function `addNewParcel`) is unfortunately not possible as the compilation order does not allow this (`dsmcParcel` is initialized later than `dsmcCloud`, therefore `dsmcParcel&` cannot be a function return type in `dsmcCloud`).