### PR TITLE
Flux surf simplification

### DIFF
--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcChapmanEnskogFreeStreamInflowPatch/dsmcChapmanEnskogFreeStreamInflowPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcChapmanEnskogFreeStreamInflowPatch/dsmcChapmanEnskogFreeStreamInflowPatch.C
@@ -416,12 +416,6 @@ void dsmcChapmanEnskogFreeStreamInflowPatch::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 parcelsInserted[m] += 1.0;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowFieldPatch/dsmcFreeStreamInflowFieldPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowFieldPatch/dsmcFreeStreamInflowFieldPatch.C
@@ -382,12 +382,6 @@ void dsmcFreeStreamInflowFieldPatch::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 parcelsInserted[m] += 1.0;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowPatch/dsmcFreeStreamInflowPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowPatch/dsmcFreeStreamInflowPatch.C
@@ -364,12 +364,6 @@ void dsmcFreeStreamInflowPatch::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 parcelsInserted[m] += 1.0;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
@@ -332,12 +332,6 @@ void dsmcIsothermalPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMov
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
@@ -332,12 +332,6 @@ void dsmcLiouFangPressureInlet::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 nTotalParcelsAdded++;
             }
         }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
@@ -342,12 +342,6 @@ void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove
                         vibLevel
                     );
 
-                    // track this parcel as having crossed the boundary face
-                    // this is justified because the trackFraction of the parcel is
-                    // initialized as a random value in the interval [0, 1].
-                    // cf. dsmcParcel::move newParcel handling.
-                    cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                     nTotalParcelsAdded++;
                     parcelsInserted[iD]++;
                 }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
@@ -305,7 +305,7 @@ void dsmcLiouFangPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMove(
                     typeId
                 );
 
-                label newParcel = 1;
+                label newParcel = patchId();
 
                 label ELevel = cloud_.equipartitionElectronicLevel
                 (

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
@@ -332,12 +332,6 @@ void dsmcLiouFangPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMove(
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
@@ -337,12 +337,6 @@ void dsmcMassFlowRateInlet::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
@@ -336,12 +336,6 @@ void dsmcNewPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 nTotalParcelsAdded++;
 
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
@@ -348,12 +348,6 @@ void dsmcWangPressureInlet::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 nTotalParcelsAdded++;
                 parcelsInserted[iD]++;
             }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
@@ -337,12 +337,6 @@ void dsmcYePressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
                     vibLevel
                 );
 
-                // track this parcel as having crossed the boundary face
-                // this is justified because the trackFraction of the parcel is
-                // initialized as a random value in the interval [0, 1].
-                // cf. dsmcParcel::move newParcel handling.
-                cloud_.tracker().trackFaceTransition(typeId, U, RWF, faces_[f]);
-
                 nTotalParcelsAdded++;
             }
         }

--- a/src/lagrangian/dsmc/clouds/dsmcCloud.C
+++ b/src/lagrangian/dsmc/clouds/dsmcCloud.C
@@ -421,6 +421,16 @@ void Foam::dsmcCloud::addNewParcel
         vibLevel
     );
 
+    // parcels that have been freshly injected on boundary patch faces should
+    // be tracked as having crossed that boundary patch face in the time step
+    // in which they have been inserted. This is justified as the trackFraction
+    // is initialized to a random value in the interval [0, 1] (cf.
+    // dsmcParcel::move newParcel handling).
+    if (newParcel != -1)
+    {
+        tracker().trackFaceTransition(typeId, U, RWF, tetFaceI);
+    }
+
     porousMeas().additionInteraction(*pPtr, newParcel);
 
     addParticle(pPtr);


### PR DESCRIPTION
As discussed in #48 

Note that using `trackParcelFaceTransition(*pPtr)` does unfortunately not work instead of the implemented `trackFaceTransition(..)`. I have tested this and the parcel seems to forget the initialized face immediately (so `*pPtr.face()` is not equal to `tetFaceI`). I did not dig any further as this is probably related to the core parcel class which I do not want to touch. 