### PR TITLE
boundaries: remove excessive output and deprecated counters

### DIFF
--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcChapmanEnskogFreeStreamInflowPatch/dsmcChapmanEnskogFreeStreamInflowPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcChapmanEnskogFreeStreamInflowPatch/dsmcChapmanEnskogFreeStreamInflowPatch.C
@@ -144,10 +144,6 @@ void dsmcChapmanEnskogFreeStreamInflowPatch::controlParcelsBeforeMove()
         }
     }
 
-
-    labelField parcelsInserted(typeIds_.size(), 0);
-    labelField parcelsToAdd(typeIds_.size(), 0);
-
     const vector& faceVelocity = velocity_;
     const scalar& faceTranslationalTemperature = translationalTemperature_;
     const scalar& faceRotationalTemperature = rotationalTemperature_;
@@ -229,7 +225,6 @@ void dsmcChapmanEnskogFreeStreamInflowPatch::controlParcelsBeforeMove()
             }
 
             faceAccumulator -= nI;
-            parcelsToAdd[m] += nI;
 
             scalar mass = cloud_.constProps(typeId).mass();
 
@@ -414,24 +409,7 @@ void dsmcChapmanEnskogFreeStreamInflowPatch::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                parcelsInserted[m] += 1.0;
             }
-        }
-    }
-
-
-    if (Pstream::parRun())
-    {
-        forAll(parcelsInserted, m)
-        {
-            reduce(parcelsToAdd[m], sumOp<scalar>());
-            reduce(parcelsInserted[m], sumOp<scalar>());
-
-            Info<< "Specie: " << typeIds_[m]
-                << ", target parcels to insert: " << parcelsToAdd[m]
-                <<", inserted parcels: " << parcelsInserted[m]
-                << endl;
         }
     }
 }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowFieldPatch/dsmcFreeStreamInflowFieldPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowFieldPatch/dsmcFreeStreamInflowFieldPatch.C
@@ -169,9 +169,6 @@ void dsmcFreeStreamInflowFieldPatch::controlParcelsBeforeMove()
         }
     }
 
-    labelField parcelsInserted(typeIds_.size(), 0);
-    labelField parcelsToAdd(typeIds_.size(), 0);
-
     // insert pacels
     forAll(faces_, f)
     {
@@ -245,7 +242,6 @@ void dsmcFreeStreamInflowFieldPatch::controlParcelsBeforeMove()
             }
 
             faceAccumulator -= nI;
-            parcelsToAdd[m] += nI;
 
             scalar mass = cloud_.constProps(typeId).mass();
 
@@ -380,21 +376,8 @@ void dsmcFreeStreamInflowFieldPatch::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                parcelsInserted[m] += 1.0;
             }
         }
-    }
-
-    forAll(parcelsInserted, m)
-    {
-       reduce(parcelsToAdd[m], sumOp<scalar>());
-       reduce(parcelsInserted[m], sumOp<scalar>());
-
-       Info<< "Patch " << patchId() << ", specie: " << typeIds_[m]
-           << ", target parcels to insert: " << parcelsToAdd[m]
-           <<", inserted parcels: " << parcelsInserted[m]
-           << endl;
     }
 }
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowPatch/dsmcFreeStreamInflowPatch.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcFreeStreamInflowPatch/dsmcFreeStreamInflowPatch.C
@@ -141,9 +141,6 @@ void dsmcFreeStreamInflowPatch::controlParcelsBeforeMove()
         }
     }
 
-    labelField parcelsInserted(typeIds_.size(), 0);
-    labelField parcelsToAdd(typeIds_.size(), 0);
-
     const vector faceVelocity = velocity_;
     const scalar faceTranslationalTemperature = translationalTemperature_;
     const scalar faceRotationalTemperature = rotationalTemperature_;
@@ -219,7 +216,6 @@ void dsmcFreeStreamInflowPatch::controlParcelsBeforeMove()
             }
 
             faceAccumulator -= nI;
-            parcelsToAdd[m] += nI;
 
             const scalar mass = cloud_.constProps(typeId).mass();
 
@@ -362,36 +358,7 @@ void dsmcFreeStreamInflowPatch::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                parcelsInserted[m] += 1.0;
             }
-        }
-    }
-
-
-    if (Pstream::parRun())
-    {
-        forAll(parcelsInserted, m)
-        {
-            reduce(parcelsToAdd[m], sumOp<scalar>());
-            reduce(parcelsInserted[m], sumOp<scalar>());
-
-            Info<< "Patch " << patchName_ << ", Specie: "
-                << cloud_.typeIdList()[typeIds_[m]]
-                << ", target parcels to insert: " << parcelsToAdd[m]
-                <<", inserted parcels: " << parcelsInserted[m]
-                << endl;
-        }
-    }
-    else
-    {
-        forAll(parcelsInserted, m)
-        {
-            Info<< "Patch " << patchName_ << ", Specie: "
-                << cloud_.typeIdList()[typeIds_[m]]
-                << ", target parcels to insert: " << parcelsToAdd[m]
-                <<", inserted parcels: " << parcelsInserted[m]
-                << endl;
         }
     }
 }

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
@@ -59,7 +59,6 @@ dsmcIsothermalPressureOutletSpecifiedMolarFraction::dsmcIsothermalPressureOutlet
     outletTemperature_(),
     outletNumberDensity_(),
     nTimeSteps_(scalar(0.0)),
-    infoCounter_(0),
     typeIds_(),
     UMean_(faces_.size(), vector::zero),
     outletVelocity_(faces_.size(), vector::zero),
@@ -115,11 +114,6 @@ void dsmcIsothermalPressureOutletSpecifiedMolarFraction::calculateProperties()
 void dsmcIsothermalPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMove()
 {
     Random& rndGen = cloud_.rndGen();
-
-    label nTotalParcelsAdded = 0;
-    label nTotalParcelsToBeAdded = 0;
-
-    labelField parcelsInserted(typeIds_.size(), 0);
 
     //loop over all species
     forAll(accumulatedParcelsToInsert_, iD)   // I Added.
@@ -185,8 +179,6 @@ void dsmcIsothermalPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMov
             }
 
             accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-            nTotalParcelsToBeAdded += nParcelsToInsert;
 
             const label& typeId = typeIds_[iD];
             scalar mass = cloud_.constProps(typeId).mass();
@@ -330,34 +322,8 @@ void dsmcIsothermalPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMov
                     0,
                     vibLevel
                 );
-
-                nTotalParcelsAdded++;
-                parcelsInserted[iD]++;
             }
         }
-
-        infoCounter_++;
-
-        if(infoCounter_ >= cloud_.nTerminalOutputs())
-        {
-            if (Pstream::parRun())
-            {
-                reduce(parcelsInserted[iD], sumOp<scalar>());
-
-                Info<< "dsmcIsothermalPressureOutletSpecifiedMolarFraction specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-            else
-            {
-                Info<< "dsmcIsothermalPressureOutletSpecifiedMolarFraction specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-
-            infoCounter_ = 0;
-        }
-
     }
 }
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.H
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.H
@@ -71,7 +71,6 @@ private:
     scalar outletTemperature_;
     scalar outletNumberDensity_;
     scalar nTimeSteps_;
-    label infoCounter_;
     labelList typeIds_;
     vectorField UMean_;
     vectorField outletVelocity_;

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
@@ -60,7 +60,6 @@ dsmcLiouFangPressureInlet::dsmcLiouFangPressureInlet
     inletVelocity_(faces_.size(), vector::zero),
     previousInletVelocity_(faces_.size(), vector::zero),
     accumulatedParcelsToInsert_(),
-    infoCounter_(0),
     inletPressure_(),
     inletTemperature_(),
     theta_(),
@@ -95,9 +94,6 @@ void dsmcLiouFangPressureInlet::calculateProperties()
 void dsmcLiouFangPressureInlet::controlParcelsBeforeMove()
 {
     Random& rndGen = cloud_.rndGen();
-
-    label nTotalParcelsAdded = 0;
-    label nTotalParcelsToBeAdded = 0;
 
     //loop over all species
     forAll(accumulatedParcelsToInsert_, iD)   // I Added.
@@ -185,8 +181,6 @@ void dsmcLiouFangPressureInlet::controlParcelsBeforeMove()
 //             }
 
             accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-            nTotalParcelsToBeAdded += nParcelsToInsert;
 
             const label& typeId = typeIds_[iD];
             scalar mass = cloud_.constProps(typeId).mass();
@@ -330,26 +324,9 @@ void dsmcLiouFangPressureInlet::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                nTotalParcelsAdded++;
             }
         }
     }
-
-    infoCounter_++;
-
-    if(infoCounter_ >= cloud_.nTerminalOutputs())
-    {
-        if(faces_.size() > VSMALL)
-        {
-            Pout<< "dsmcLiouFangPressureInlet target parcels to insert: " << nTotalParcelsToBeAdded
-                <<", number of of inserted parcels: " << nTotalParcelsAdded
-                << endl;
-        }
-
-        infoCounter_ = 0;
-    }
-
     previousInletVelocity_ = inletVelocity_;
 }
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.H
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.H
@@ -71,7 +71,6 @@ private:
     vectorField inletVelocity_;
     vectorField previousInletVelocity_;
     List <scalarField> accumulatedParcelsToInsert_;
-    label infoCounter_;
     scalar inletPressure_;
     scalar inletTemperature_;
     scalar theta_;

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
@@ -115,9 +115,6 @@ void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove
     {
         Random& rndGen = cloud_.rndGen();
 
-        label nTotalParcelsAdded = 0;
-        label nTotalParcelsToBeAdded = 0;
-
         forAll(moleFractions_, iD)
         {
             forAll(moleFractions_[iD], c)
@@ -128,9 +125,6 @@ void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove
                 }
             }
         }
-
-        labelField parcelsInserted(typeIds_.size(), 0);
-        scalarField averageMoleFractions(moleFractions_.size(), 0.0);
 
         forAll(accumulatedParcelsToInsert_, iD)
         {
@@ -195,8 +189,6 @@ void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove
                 }
 
                 accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-                nTotalParcelsToBeAdded += nParcelsToInsert;
 
                 const label& typeId = typeIds_[iD];
                 scalar mass = cloud_.constProps(typeId).mass();
@@ -340,48 +332,10 @@ void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove
                         0,
                         vibLevel
                     );
-
-                    nTotalParcelsAdded++;
-                    parcelsInserted[iD]++;
                 }
             }
-
-            if (Pstream::parRun())
-            {
-                reduce(parcelsInserted[iD], sumOp<scalar>());
-
-                Info<< "dsmcLiouFangPressureOutletCalculatedMolarFraction specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-            else
-            {
-                Info<< "dsmcLiouFangPressureOutletCalculatedMolarFraction specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-        }
-
-        forAll(moleFractions_, iD)
-        {
-            forAll(moleFractions_[iD], f)
-            {
-                averageMoleFractions[iD] += moleFractions_[iD][f];
-            }
-
-            averageMoleFractions[iD] /= moleFractions_[iD].size();
-        }
-
-        if (Pstream::parRun())
-        {
-            Info << "moleFractions = " << averageMoleFractions << endl;
-        }
-        else
-        {
-            Info << "moleFractions = " << averageMoleFractions << endl;
         }
     }
-
 }
 
 void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsBeforeCollisions()

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
@@ -58,7 +58,6 @@ dsmcLiouFangPressureOutletSpecifiedMolarFraction::dsmcLiouFangPressureOutletSpec
     propsDict_(dict.subDict(typeName + "Properties")),
     outletPressure_(),
     nTimeSteps_(scalar(0.0)),
-    infoCounter_(0),
     typeIds_(),
     UMean_(faces_.size(), vector::zero),
     outletVelocity_(faces_.size(), vector::zero),
@@ -115,11 +114,6 @@ void dsmcLiouFangPressureOutletSpecifiedMolarFraction::calculateProperties()
 void dsmcLiouFangPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMove()
 {
     Random& rndGen = cloud_.rndGen();
-
-    label nTotalParcelsAdded = 0;
-    label nTotalParcelsToBeAdded = 0;
-
-    labelField parcelsInserted(typeIds_.size(), 0);
 
     //loop over all species
     forAll(accumulatedParcelsToInsert_, iD)   // I Added.
@@ -185,8 +179,6 @@ void dsmcLiouFangPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMove(
             }
 
             accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-            nTotalParcelsToBeAdded += nParcelsToInsert;
 
             const label& typeId = typeIds_[iD];
             scalar mass = cloud_.constProps(typeId).mass();
@@ -330,34 +322,8 @@ void dsmcLiouFangPressureOutletSpecifiedMolarFraction::controlParcelsBeforeMove(
                     0,
                     vibLevel
                 );
-
-                nTotalParcelsAdded++;
-                parcelsInserted[iD]++;
             }
         }
-
-        infoCounter_++;
-
-        if(infoCounter_ >= cloud_.nTerminalOutputs())
-        {
-            if (Pstream::parRun())
-            {
-                reduce(parcelsInserted[iD], sumOp<scalar>());
-
-                Info<< "dsmcLiouFangPressureOutletSpecifiedMolarFraction specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-            else
-            {
-                Info<< "dsmcLiouFangPressureOutletSpecifiedMolarFraction specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-
-            infoCounter_ = 0;
-        }
-
     }
 }
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.H
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.H
@@ -69,7 +69,6 @@ private:
 
     scalar outletPressure_;
     scalar nTimeSteps_;
-    label infoCounter_;
     labelList typeIds_;
     vectorField UMean_;
     vectorField outletVelocity_;

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
@@ -99,11 +99,6 @@ void dsmcMassFlowRateInlet::controlParcelsBeforeMove()
 {
     Random& rndGen = cloud_.rndGen();
 
-    label nTotalParcelsAdded = 0;
-    label nTotalParcelsToBeAdded = 0;
-
-    labelField parcelsInserted(typeIds_.size(), 0);
-
     //loop over all species
     forAll(accumulatedParcelsToInsert_, iD)   // I Added.
     {
@@ -190,8 +185,6 @@ void dsmcMassFlowRateInlet::controlParcelsBeforeMove()
 //             }
 
             accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-            nTotalParcelsToBeAdded += nParcelsToInsert;
 
             const label& typeId = typeIds_[iD];
             scalar mass = cloud_.constProps(typeId).mass();
@@ -335,31 +328,10 @@ void dsmcMassFlowRateInlet::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                nTotalParcelsAdded++;
-                parcelsInserted[iD]++;
             }
         }
-
-        if (Pstream::parRun())
-        {
-            reduce(parcelsInserted[iD], sumOp<scalar>());
-
-            Info<< "dsmcMassFlowRateInlet specie: " << typeIds_[iD]
-                <<", inserted parcels: " << parcelsInserted[iD]
-                << endl;
-        }
-        else
-        {
-            Info<< "dsmcMassFlowRateInlet specie: " << typeIds_[iD]
-                <<", inserted parcels: " << parcelsInserted[iD]
-                << endl;
-        }
     }
-
-
     previousInletVelocity_ = inletVelocity_;
-
 }
 
 void dsmcMassFlowRateInlet::controlParcelsBeforeCollisions()

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
@@ -126,9 +126,6 @@ void dsmcNewPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
 {
     Random& rndGen = cloud_.rndGen();
 
-    label nTotalParcelsAdded = 0;
-    label nTotalParcelsToBeAdded = 0;
-
     forAll(accumulatedParcelsToInsert_, iD)   // I Added.
     {
         // loop over all faces of the patch
@@ -194,8 +191,6 @@ void dsmcNewPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
             }
 
             accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-            nTotalParcelsToBeAdded += nParcelsToInsert;
 
             const label& typeId = typeIds_[iD];
             scalar mass = cloud_.constProps(typeId).mass();
@@ -334,16 +329,9 @@ void dsmcNewPressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                nTotalParcelsAdded++;
-
             }
         }
     }
-
-    Info<< "dsmcNewPressureOutletCalculatedMolarFraction target parcels to insert: " << nTotalParcelsToBeAdded
-        <<", number of inserted parcels: " << nTotalParcelsAdded
-        << endl;
 }
 
 void dsmcNewPressureOutletCalculatedMolarFraction::controlParcelsBeforeCollisions()

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
@@ -57,7 +57,6 @@ dsmcWangPressureInlet::dsmcWangPressureInlet
     propsDict_(dict.subDict(typeName + "Properties")),
     typeIds_(),
     moleFractions_(),
-    infoCounter_(0),
     inletPressure_(),
     inletTemperature_(),
     n_(),
@@ -109,11 +108,6 @@ void dsmcWangPressureInlet::calculateProperties()
 void dsmcWangPressureInlet::controlParcelsBeforeMove()
 {
     Random& rndGen = cloud_.rndGen();
-
-    label nTotalParcelsAdded = 0;
-    label nTotalParcelsToBeAdded = 0;
-
-    labelField parcelsInserted(typeIds_.size(), 0);
 
     //loop over all species
     forAll(accumulatedParcelsToInsert_, iD)   // I Added.
@@ -201,8 +195,6 @@ void dsmcWangPressureInlet::controlParcelsBeforeMove()
             }
 
             accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-            nTotalParcelsToBeAdded += nParcelsToInsert;
 
             const label& typeId = typeIds_[iD];
             scalar mass = cloud_.constProps(typeId).mass();
@@ -346,42 +338,9 @@ void dsmcWangPressureInlet::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                nTotalParcelsAdded++;
-                parcelsInserted[iD]++;
             }
         }
-
-        infoCounter_++;
-
-        if(infoCounter_ >= cloud_.nTerminalOutputs())
-        {
-            if (Pstream::parRun())
-            {
-                reduce(parcelsInserted[iD], sumOp<scalar>());
-
-                Info<< "dsmcWangPressureInlet specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-            else
-            {
-                Info<< "dsmcWangPressureInlet specie: " << typeIds_[iD]
-                    <<", inserted parcels: " << parcelsInserted[iD]
-                    << endl;
-            }
-
-            infoCounter_ = 0;
-        }
-
     }
-
-//     if(faces_.size() > VSMALL)
-//     {
-//         Pout<< "dsmcWangPressureInlet target parcels to insert: " << nTotalParcelsToBeAdded
-//             <<", number of inserted parcels: " << nTotalParcelsAdded
-//             << endl;
-//     }
 }
 
 void dsmcWangPressureInlet::controlParcelsBeforeCollisions()

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.H
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.H
@@ -69,7 +69,6 @@ private:
 
     labelList typeIds_;  // I Added.
     scalarField moleFractions_; // I Added.
-    label infoCounter_;
     scalar inletPressure_;
     scalar inletTemperature_;
     scalar n_; // inlet number density

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
@@ -127,9 +127,6 @@ void dsmcYePressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
 {
     Random& rndGen = cloud_.rndGen();
 
-    label nTotalParcelsAdded = 0;
-    label nTotalParcelsToBeAdded = 0;
-
     forAll(accumulatedParcelsToInsert_, iD)   // I Added.
     {
         // loop over all faces of the patch
@@ -195,8 +192,6 @@ void dsmcYePressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
             }
 
             accumulatedParcelsToInsert_[iD][f] -= nParcelsToInsert; //remainder has been set
-
-            nTotalParcelsToBeAdded += nParcelsToInsert;
 
             const label& typeId = typeIds_[iD];
             scalar mass = cloud_.constProps(typeId).mass();
@@ -335,15 +330,9 @@ void dsmcYePressureOutletCalculatedMolarFraction::controlParcelsBeforeMove()
                     0,
                     vibLevel
                 );
-
-                nTotalParcelsAdded++;
             }
         }
     }
-
-    Info<< "dsmcYePressureOutletCalculatedMolarFraction target parcels to insert: " << nTotalParcelsToBeAdded
-        <<", number of inserted parcels: " << nTotalParcelsAdded
-        << endl;
 }
 
 void dsmcYePressureOutletCalculatedMolarFraction::controlParcelsBeforeCollisions()


### PR DESCRIPTION
Hi,
this removes the excessive output from the boundaries in the solver logs. Some of them had "better" output conditions than others, however, I think in general this information is not really useful and just decreases readability whilst increasing size of logs.

Additionally several of them had two different counting mechanisms implemented (1 deprecated), so I removed both.