### PR TITLE
hy2Foam: Fix range check of accommodation coefficient

### DIFF
--- a/applications/solvers/compressible/hy2Foam/BCs/T/nonEqPattersonJumpT/nonEqPattersonJumpTFvPatchScalarField.C
+++ b/applications/solvers/compressible/hy2Foam/BCs/T/nonEqPattersonJumpT/nonEqPattersonJumpTFvPatchScalarField.C
@@ -99,7 +99,7 @@ Foam::nonEqPattersonJumpTFvPatchScalarField::nonEqPattersonJumpTFvPatchScalarFie
     if
     (
         mag(accommodationCoeff_) < SMALL
-     || mag(accommodationCoeff_) > 2.0
+     || mag(accommodationCoeff_) > 1.0
     )
     {
         FatalIOErrorIn

--- a/applications/solvers/compressible/hy2Foam/BCs/T/nonEqSmoluchowskiJumpT/nonEqSmoluchowskiJumpTFvPatchScalarField.C
+++ b/applications/solvers/compressible/hy2Foam/BCs/T/nonEqSmoluchowskiJumpT/nonEqSmoluchowskiJumpTFvPatchScalarField.C
@@ -99,7 +99,7 @@ Foam::nonEqSmoluchowskiJumpTFvPatchScalarField::nonEqSmoluchowskiJumpTFvPatchSca
     if
     (
         mag(accommodationCoeff_) < SMALL
-     || mag(accommodationCoeff_) > 2.0
+     || mag(accommodationCoeff_) > 1.0
     )
     {
         FatalIOErrorIn

--- a/applications/solvers/compressible/hy2Foam/BCs/T/nonEqSmoluchowskiJumpTv/nonEqSmoluchowskiJumpTvFvPatchScalarField.C
+++ b/applications/solvers/compressible/hy2Foam/BCs/T/nonEqSmoluchowskiJumpTv/nonEqSmoluchowskiJumpTvFvPatchScalarField.C
@@ -106,7 +106,7 @@ Foam::nonEqSmoluchowskiJumpTvFvPatchScalarField::nonEqSmoluchowskiJumpTvFvPatchS
     if
     (
         mag(accommodationCoeff_) < SMALL
-     || mag(accommodationCoeff_) > 2.0
+     || mag(accommodationCoeff_) > 1.0
     )
     {
         FatalIOErrorIn

--- a/applications/solvers/compressible/hy2Foam/BCs/T/nonEqSmoluchowskiJumpTvMix/nonEqSmoluchowskiJumpTvMixFvPatchScalarField.C
+++ b/applications/solvers/compressible/hy2Foam/BCs/T/nonEqSmoluchowskiJumpTvMix/nonEqSmoluchowskiJumpTvMixFvPatchScalarField.C
@@ -94,7 +94,7 @@ Foam::nonEqSmoluchowskiJumpTvMixFvPatchScalarField::nonEqSmoluchowskiJumpTvMixFv
     if
     (
         mag(accommodationCoeff_) < SMALL
-     || mag(accommodationCoeff_) > 2.0
+     || mag(accommodationCoeff_) > 1.0
     )
     {
         FatalIOErrorIn

--- a/applications/solvers/compressible/hy2Foam/BCs/U/nonEqMaxwellSlipUFvPatchVectorField.C
+++ b/applications/solvers/compressible/hy2Foam/BCs/U/nonEqMaxwellSlipUFvPatchVectorField.C
@@ -98,7 +98,7 @@ Foam::nonEqMaxwellSlipUFvPatchVectorField::nonEqMaxwellSlipUFvPatchVectorField
     if
     (
         mag(accommodationCoeff_) < SMALL
-     || mag(accommodationCoeff_) > 2.0
+     || mag(accommodationCoeff_) > 1.0
     )
     {
         FatalIOErrorIn


### PR DESCRIPTION
If I am not mistaken (which the error message also supports) the accommodation coefficient is strictly limited to the interval [0, 1].