### PR TITLE
dsmcFoam+: Add option resetAtOutputUntilTime

### DIFF
--- a/src/lagrangian/dsmc/macroscopicProperties/basic/dsmcField/dsmcField.C
+++ b/src/lagrangian/dsmc/macroscopicProperties/basic/dsmcField/dsmcField.C
@@ -120,6 +120,36 @@ void dsmcField::updateBasicFieldProperties
     {
         time_.resetFieldsAtOutput() = Switch(timeDict_.lookup("resetAtOutput"));
     }
+
+    // this additional option will work in conjunction with resetAtOutput in the
+    // following way:
+    //   1. resetAtOutput = true:
+    //     1. if time <= resetAtOutputUntilTime -> reset at output
+    //     2. if time > resetAtOutputUntilTime -> do not reset at output
+    //   2. resetAtOutput = false -> no effect
+
+    if
+    (
+           time_.resetFieldsAtOutput()
+        && timeDict_.found("resetAtOutputUntilTime")
+    )
+    {
+        const scalar resetAtOutputUntilTime =
+            readScalar(timeDict_.lookup("resetAtOutputUntilTime"));
+
+        // the fields of the current time step have already been written,
+        // therefore the following belongs to the _next_ period (until next
+        // output time is reached)
+        if
+        (
+              time_.time().value()
+            + time_.time().deltaT().value()
+            > resetAtOutputUntilTime
+        )
+        {
+            time_.resetFieldsAtOutput() = false;
+        }
+    }
 }
 
 const fileName& dsmcField::casePath() const

--- a/src/lagrangian/dsmc/macroscopicProperties/basic/dsmcFieldProperties/dsmcFieldProperties.C
+++ b/src/lagrangian/dsmc/macroscopicProperties/basic/dsmcFieldProperties/dsmcFieldProperties.C
@@ -111,6 +111,9 @@ dsmcFieldProperties::dsmcFieldProperties
             fieldIds_[f] = f;
 
             fields_[f]->casePath() = fieldPath;
+
+            // update field properties from dict
+            fields_[f]->updateProperties(fieldIDict);
         }
     }
 }

--- a/src/lagrangian/dsmc/macroscopicProperties/derived/combined/dsmcVolFields/dsmcVolFields.C
+++ b/src/lagrangian/dsmc/macroscopicProperties/derived/combined/dsmcVolFields/dsmcVolFields.C
@@ -912,10 +912,19 @@ void dsmcVolFields::createField()
     //- read in stored data from dictionary
     if (averagingAcrossManyRuns_)
     {
-        Info<< "Averaging across many runs enabled." << nl
-            << endl;
-
-        readIn();
+        if (!time_.resetFieldsAtOutput())
+        {
+            Info<< "Averaging across many runs for field " << fieldName_
+                << " is enabled. Averaging data will be read from file."
+                << endl;
+            readIn();
+        }
+        else
+        {
+            Info<< "Averaging across many runs for field " << fieldName_
+                << " will be enabled as soon as resetAtOutput is turned off."
+                << endl;
+        }
     }
 }
 
@@ -2492,7 +2501,7 @@ void dsmcVolFields::calculateField()
             }
         }
 
-        if (averagingAcrossManyRuns_)
+        if (averagingAcrossManyRuns_ && !time_.resetFieldsAtOutput())
         {
             writeOut();
         }


### PR DESCRIPTION
Hi,
this implements two changes:
- `averagingAcrossManyRuns` mode is a bit smarter and only reads/writes if resetAtOutput is turned off
- added option `resetAtOutputUntilTime`, which allows to turn off resetting at the output after a specified time step

The second option works like this:
1. `resetAtOutput = off`: no effect
2. `resetAtOutput = on`:
  - while `t <= resetAtOutputUntilTime`: reset at output
  - while `t > resetAtOutputUntilTime`: do not reset at output

The benefit is that this setting was often emulated with a shell script that turned off `resetAtOutput` after a sleep period. Now this is available directly.

Edit: this new setting is of course completely optional.
