### PR TITLE
dsmcFoam+: dynamic load balancing: add balanceUntilTime option

### DIFF
--- a/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
+++ b/src/lagrangian/dsmc/dynamicLoadBalancing/dsmcDynamicLoadBalancing.H
@@ -68,6 +68,8 @@ class dsmcDynamicLoadBalancing
 
         bool enableBalancing_;
 
+        scalar balanceUntilTime_;
+
         scalar originalEndTime_;
 
         scalar maxImbalance_;


### PR DESCRIPTION
Hi,
this adds a new option to dynamic load balancing that allows to set a time after which load balancing will be turned off. This is useful in conjunction with the resetAtOutputUntilTime option that I have added in another merge request.