### PR TITLE
add mhdModels folder to copy list in "build/install-CFD.sh"

### DIFF
--- a/build/install-CFD.sh
+++ b/build/install-CFD.sh
@@ -17,7 +17,7 @@ mkdir -p $sendingDir
 
 
 # copy new files --------------------------------------------------------------
-foldersSrc="thermophysicalModels TurbulenceModels hTCModels finiteVolume fvOptions functionObjects/forces functionObjects/field-cfdStrath"
+foldersSrc="thermophysicalModels TurbulenceModels hTCModels mhdModels finiteVolume fvOptions functionObjects/forces functionObjects/field-cfdStrath"
 filesInFolderSrc="functionObjects"
 foldersApp="solvers/compressible/hy2Foam utilities/mesh/generation/makeAxialMesh utilities/mesh/generation/blockMeshDG"
 


### PR DESCRIPTION
lack of "mhdModels" folder in copy list was causing install/build errors. Successfully builds after adding, tested with fresh install of OF-1706