### PR TITLE
Fix index out of range fatal error

### DIFF
--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcIsothermalPressureOutletSpecifiedMolarFraction/dsmcIsothermalPressureOutletSpecifiedMolarFraction.C
@@ -612,7 +612,7 @@ void dsmcIsothermalPressureOutletSpecifiedMolarFraction::controlParcelsAfterColl
             const vector& sF = mesh_.faceAreas()[faceI];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
             scalar mass = cloud_.constProps(typeId).mass();
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureInlet/dsmcLiouFangPressureInlet.C
@@ -383,7 +383,7 @@ void dsmcLiouFangPressureInlet::controlParcelsAfterCollisions()
             const vector& sF = mesh_.faceAreas()[faceI];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
                 scalar mass = cloud_.constProps(typeId).mass();
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletCalculatedMolarFraction/dsmcLiouFangPressureOutletCalculatedMolarFraction.C
@@ -537,7 +537,7 @@ void dsmcLiouFangPressureOutletCalculatedMolarFraction::controlParcelsAfterColli
             const vector& sF = mesh_.faceAreas()[faceI];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
             scalar mass = cloud_.constProps(typeId).mass();
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcLiouFangPressureOutletSpecifiedMolarFraction/dsmcLiouFangPressureOutletSpecifiedMolarFraction.C
@@ -611,7 +611,7 @@ void dsmcLiouFangPressureOutletSpecifiedMolarFraction::controlParcelsAfterCollis
             const vector& sF = mesh_.faceAreas()[faceI];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
             scalar mass = cloud_.constProps(typeId).mass();
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcMassFlowRateInlet/dsmcMassFlowRateInlet.C
@@ -424,7 +424,7 @@ void dsmcMassFlowRateInlet::controlParcelsAfterCollisions()
             const vector& sF = mesh_.faceAreas()[faceI];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
             scalar mass = cloud_.constProps(typeId).mass();
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcNewPressureOutletCalculatedMolarFraction/dsmcNewPressureOutletCalculatedMolarFraction.C
@@ -590,7 +590,7 @@ void dsmcNewPressureOutletCalculatedMolarFraction::controlParcelsAfterCollisions
             const vector& sF = mesh_.faceAreas()[faces_[f]];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
             scalar mass = cloud_.constProps(typeId).mass();
 

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcWangPressureInlet/dsmcWangPressureInlet.C
@@ -486,7 +486,7 @@ void dsmcWangPressureInlet::controlParcelsAfterCollisions()
             const vector& sF = mesh_.faceAreas()[faceI];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
             scalar mostProbableSpeed
             (

--- a/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
+++ b/src/lagrangian/dsmc/boundaries/derived/generalBoundaries/dsmcYePressureOutletCalculatedMolarFraction/dsmcYePressureOutletCalculatedMolarFraction.C
@@ -587,7 +587,7 @@ void dsmcYePressureOutletCalculatedMolarFraction::controlParcelsAfterCollisions(
             const vector& sF = mesh_.faceAreas()[faceI];
             const scalar fA = mag(sF);
 
-            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[faceI]);
+            const scalar deltaT = cloud_.deltaTValue(mesh_.boundaryMesh()[patchId_].faceCells()[f]);
 
             scalar mass = cloud_.constProps(typeId).mass();
 


### PR DESCRIPTION
Some boundary conditions could not be used, because a wrong index was used to access a cell in delta time calculation.